### PR TITLE
Feature/flexible timestep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project should be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2019-07-09
+
+- Added ability to set number of days for the timestep instead of
+  day, week, or month. This is useful if the pest has multiple generations
+  in a year (Chris Jones)
+
 ## 2019-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Added ability to set number of days for the timestep instead of
   day, week, or month. This is useful if the pest has multiple generations
-  in a year (Chris Jones)
+  in a year. (Chris Jones)
+  
+### Changed
+  
+- Made extension of the 52 week to be 8 or 9 (leap years) days instead of 
+  7 to ensure that the next year starts on Jan 1st. This makes forecasting
+  into the future more streamlined. (Chris Jones)
 
 ## 2019-06-14
 

--- a/TECHNICALDEBT.md
+++ b/TECHNICALDEBT.md
@@ -17,6 +17,10 @@ issue which needs to be fixed (Fix).
 Entries should be removed when resolved. Issue from tracker can be
 optionally linked in an entry.
 
+## 2019-07-09
+
+- Tests need to be written for weekly, daily, and multi-day timesteps for Date functionality.
+
 ## 2019-06-14
 
 ### Add

--- a/date.hpp
+++ b/date.hpp
@@ -42,6 +42,8 @@ private:
 public:
     Date(const Date& d): year_(d.year_), month_(d.month_), day_(d.day_) {}
     Date(int y, int m, int d): year_(y), month_(m), day_(d) {}
+    int num_days;
+    inline void increased_by_days(int num_days);
     inline void increased_by_week();
     inline void increased_by_month();
     inline Date get_year_end();
@@ -140,6 +142,41 @@ bool operator< (const Date &d1, const Date &d2)
 bool operator>= (const Date &d1, const Date &d2)
 {
     return !(d1 < d2);
+}
+
+void Date::increased_by_days(int num_days)
+{
+  day_ += num_days;
+  if (year_ % 4 == 0 && (year_ % 100 != 0 || year_ % 400 == 0)) {
+    if (month_ == 12 && day_ > (31 - (num_days + 1))) {
+      year_++;
+      month_ = 1;
+      day_ = 1;
+    }
+    if (day_ > day_in_month[1][month_]) {
+      day_ = day_ - day_in_month[1][month_];
+      month_++;
+      if (month_ > 12) {
+        year_++;
+        month_ = 1;
+      }
+    }
+  }
+  else {
+    if (month_ == 12 && day_ > (31 - num_days)) {
+      year_++;
+      month_ = 1;
+      day_ = 1;
+    }
+    if (day_ > day_in_month[0][month_]) {
+      day_ = day_ - day_in_month[0][month_];
+      month_++;
+      if (month_ > 12) {
+        year_++;
+        month_ = 1;
+      }
+    }
+  }
 }
 
 void Date::increased_by_week()

--- a/date.hpp
+++ b/date.hpp
@@ -5,6 +5,7 @@
  *
  * Authors: Zexi Chen (zchen22 ncsu edu)
  *          Anna Petrasova
+ *          Chris Jones
  *
  * The code contained herein is licensed under the GNU General Public
  * License. You may obtain a copy of the GNU General Public License
@@ -42,7 +43,6 @@ private:
 public:
     Date(const Date& d): year_(d.year_), month_(d.month_), day_(d.day_) {}
     Date(int y, int m, int d): year_(y), month_(m), day_(d) {}
-    int num_days;
     inline void increased_by_days(int num_days);
     inline void increased_by_week();
     inline void increased_by_month();
@@ -144,6 +144,15 @@ bool operator>= (const Date &d1, const Date &d2)
     return !(d1 < d2);
 }
 
+/*!
+ * Increases the date by the num_days (specified by the user) except on
+ * the last timestep of the year, which is increased by num_days 
+ * plus the number of  days left in the year that are less
+ * than num_days (e.g. if the num_days = 28 the last time step is 29
+ * or 30 (if leap year), if num_days = 23 that last time step is 43
+ * or 44 (if leap year) days). This ensures that each year of the 
+ * forecast starts on January 1st. 
+ */
 void Date::increased_by_days(int num_days)
 {
   day_ += num_days;
@@ -179,6 +188,11 @@ void Date::increased_by_days(int num_days)
   }
 }
 
+/*!
+ * Increases the date by one week (7 days) except on the last week
+ * of the year, which is increased by 8 or 9 days if a leap year.
+ * This ensures that each year of the forecast starts on January 1st. 
+ */
 void Date::increased_by_week()
 {
     day_ += 7;

--- a/date.hpp
+++ b/date.hpp
@@ -146,6 +146,11 @@ void Date::increased_by_week()
 {
     day_ += 7;
     if (year_ % 4 == 0 && (year_ % 100 != 0 || year_ % 400 == 0)) {
+        if (month_ == 12 && day_ > 23) {
+            year_++;
+            month_ = 1;
+            day_ = 1;
+        }
         if (day_ > day_in_month[1][month_]) {
             day_ = day_ - day_in_month[1][month_];
             month_++;
@@ -156,6 +161,11 @@ void Date::increased_by_week()
         }
     }
     else {
+        if (month_ == 12 && day_ > 24) {
+            year_++;
+            month_ = 1;
+            day_ = 1;
+        }
         if (day_ > day_in_month[0][month_]) {
             day_ = day_ - day_in_month[0][month_];
             month_++;


### PR DESCRIPTION
I added the functionality for multi-day timestep when needed and truncation of the final week during weekly timesteps so that the first day of every year is always January 1st. If approved I can merge.