### PR TITLE
Complete rewrite of dispersal kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project should be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2019-08-11 - Dispersal kernel rewrite
+
+### Added
+
+- Radial exponential kernel and a uniform kernel (Vaclav Petras)
+  * Any combination of kernels is now possible on the library level.
+- Functions to convert from strings to kernel-related enums.
+
+### Changed
+
+- Dispersal kernel are organized as classes (functors). (Vaclav Petras)
+  * The disperse function is now a function template in the Simulation.
+  * Dispersal kernel is a function (functor) called from the Simulation.
+  * The Simulation class does not have any kernel-related parameters
+    or members.
+- Usage of std::cout related to kernels was replaced by exceptions
+  in the new code. (Vaclav Petras)
+- Kernel-related enums are not strongly typed using enum class
+  (Vaclav Petras)
+
+### Fixed
+
+- A call to abs function on the distance used for spread caused
+  conversion to int. Now std::abs is used so double is used throughout.
+  This changes simulation results. (Vaclav Petras)
+- Resolution is now double instead of int. This changes results in cases
+  when the resolution is not a integer number (even when it is
+  so close to the closest higher integer that it is printed out without
+  any decimal places by software considering it, possibly correctly,
+  close enough from user perspective). This was also reported in the
+  issue #26. (Vaclav Petras)
+
 ## 2019-07-11
 
 ### Added

--- a/TECHNICALDEBT.md
+++ b/TECHNICALDEBT.md
@@ -17,7 +17,27 @@ issue which needs to be fixed (Fix).
 Entries should be removed when resolved. Issue from tracker can be
 optionally linked in an entry.
 
+## 2019-08-11 - Dispersal kernel rewrite
+
+### Add
+
+- Tests for kernel classes
+- Documentation on how to use the kernel classes
+- Support more spelling options for the types and wind directions.
+- Better documentation for the short-long kernel.
+- Better documentation or code related to reset() function of
+  distributions.
+- Add script for automatic code indentation.
+
+### Change
+
+- Indices and sizes should be template parameters as some matrix or
+  raster libraries may use different types, e.g., Rcpp uses int as
+  indices while Armadillo uses typedef for an unsigned integer.
+
 ## 2019-07-09
+
+### Add
 
 - Tests need to be written for weekly, daily, and multi-day timesteps for Date functionality.
 

--- a/kernel.hpp
+++ b/kernel.hpp
@@ -1,0 +1,82 @@
+/*
+ * PoPS model - main disperal kernel
+ *
+ * Copyright (C) 2019 by the authors.
+ *
+ * Authors: Vaclav Petras (wenzeslaus gmail com)
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+/*! \file kernel.hpp
+ *
+ * \brief Main entry point to dispersal kernel funcionality
+ *
+ * This file contains convenient definitions or wrappers to be used
+ * when using this library.
+ *
+ * ## Adding a new kernel
+ *
+ * To add new kernel, decide if it needs to be a separate class,
+ * or if it is just a parameterization of the existing kernel.
+ * Many kernels can be handled by the RadialDispersalKernel class.
+ *
+ * Generally, such class needs to provide contructor taking all required
+ * parameters and a function call operator which takes a random number
+ * generator object and returns a pair of coordinates as row and column.
+ * The signature of the function template should be:
+ *
+ * ```
+ * template<typename Generator>
+ * std::tuple<int, int> operator() (Generator& generator)
+ * ```
+ *
+ * Besides implementation in a class, enum for the different types
+ * of kernels needs to be extented as well as function which transforms
+ * strings into enum values, i.e., you need to add to the
+ * `DispersalKernelType` enum and extend the kernel_type_from_string()
+ * function in kernel_types.hpp.
+ */
+
+#ifndef POPS_KERNEL_HPP
+#define POPS_KERNEL_HPP
+
+#include "switch_kernel.hpp"
+#include "short_long_kernel.hpp"
+
+namespace pops {
+
+/*! Dispersal kernel supporting all available kernels for short and long
+ * distance spread.
+ *
+ * This is a typedef defining the main disperal kernel class in the PoPS
+ * library. When you are using the library, this is default choice.
+ *
+ * The choices which are allowed by this class are:
+ * ```
+ *                     kernel type
+ *                    /           \
+ *                   /             \
+ *               short              long
+ *             /   |   \          /   |   \
+ *        radial uniform ...   radial uniform ...
+ *        /  | \_____                 |
+ *       /   |       \                |
+ * cauchy exponential ...            ...
+ * ```
+ * The ellipses represent whatever the SwitchDispersalKernel and
+ * RadialDispersalKernel classes support.
+ *
+ * See ShortLongDispersalKernel and SwitchDispersalKernel for further
+ * documentation.
+ */
+typedef ShortLongDispersalKernel<SwitchDispersalKernel, SwitchDispersalKernel> DispersalKernel;
+
+} // namespace pops
+
+#endif // POPS_KERNEL_HPP

--- a/kernel_types.hpp
+++ b/kernel_types.hpp
@@ -1,0 +1,82 @@
+/*
+ * PoPS model - disperal kernel types
+ *
+ * Copyright (C) 2015-2019 by the authors.
+ *
+ * Authors: Vaclav Petras (wenzeslaus gmail com)
+ *          Chris Jones (cjones1688 gmail com)
+ *          Anna Petrasova (kratochanna gmail com)
+ *          Zexi Chen (zchen22 ncsu edu)
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+/*! \file kernel_types.hpp
+ *
+ * \brief Kernel types enum and helper functions.
+ *
+ * This file contains general functionality shared in general by all
+ * kernels.
+ *
+ * An alternative implementation would be for each class to mainain its
+ * own enum of supported kernels, potentially creatng a hiearchy of
+ * kernel types and subtypes. This would avoid the need for a separate
+ * header file such as this one due to all kernels potentially
+ * depending on it which prevents us from having it in the same header
+ * file like the main or default interface. However, this is easier for
+ * actually using the library as all kernel types are resolved by one
+ * function and one variable in the user code.
+ */
+
+#ifndef POPS_KERNEL_TYPES_HPP
+#define POPS_KERNEL_TYPES_HPP
+
+#include <string>
+#include <stdexcept>
+
+namespace pops {
+
+/*! Type of dispersal kernel
+ *
+ * This contains all kernels supported by the PoPS library
+ * and it may be further used by the various classes which support
+ * more than one kernel type.
+ *
+ * None is to represent no spread in the given context, e.g., no long
+ * distance spread.
+ */
+enum class DispersalKernelType
+{
+    Cauchy,  //!< Cauchy dispersal kernel
+    Exponential,  //!< Exponential dispersal kernel
+    Uniform,  //!< Random uniform dispersal kernel
+    None,  //!< No dispersal kernel (no spread)
+};
+
+/*! Get a corresponding enum value for a string which is a kernel name.
+ *
+ * Throws an std::invalid_argument exception if the values was not
+ * found or is not supported (which is the same thing).
+ */
+inline
+DispersalKernelType kernel_type_from_string(const std::string& text)
+{
+    if (text == "cauchy")
+        return DispersalKernelType::Cauchy;
+    else if (text == "exponential")
+        return DispersalKernelType::Exponential;
+    else if (text == "uniform")
+        return DispersalKernelType::Uniform;
+    else
+        throw std::invalid_argument("kernel_type_from_string: Invalid"
+                                    " value '" + text +"' provided");
+}
+
+} // namespace pops
+
+#endif // POPS_KERNEL_TYPES_HPP

--- a/kernel_types.hpp
+++ b/kernel_types.hpp
@@ -72,9 +72,22 @@ DispersalKernelType kernel_type_from_string(const std::string& text)
         return DispersalKernelType::Exponential;
     else if (text == "uniform")
         return DispersalKernelType::Uniform;
+    else if (text == "none" || text == "None"
+             || text == "NONE" || text.empty())
+        return DispersalKernelType::None;
     else
         throw std::invalid_argument("kernel_type_from_string: Invalid"
                                     " value '" + text +"' provided");
+}
+
+/*! Overload which allows to pass C-style string which is nullptr (NULL)
+ */
+inline
+DispersalKernelType kernel_type_from_string(const char* text)
+{
+    // call the string version
+    return kernel_type_from_string(text ? std::string(text)
+                                        : std::string());
 }
 
 } // namespace pops

--- a/radial_kernel.hpp
+++ b/radial_kernel.hpp
@@ -144,6 +144,16 @@ Direction direction_from_string(const std::string& text)
     }
 }
 
+/*! Overload which allows to pass C-style string which is nullptr (NULL)
+ */
+inline
+Direction direction_from_string(const char* text)
+{
+    // call the string version
+    return direction_from_string(text ? std::string(text)
+                                      : std::string());
+}
+
 /*! Dispersal kernel providing all the radial kernels.
  *
  * We understand a radial kernel to be a kernel which has parameters

--- a/radial_kernel.hpp
+++ b/radial_kernel.hpp
@@ -1,0 +1,244 @@
+/*
+ * PoPS model - radial disperal kernel
+ *
+ * Copyright (C) 2015-2019 by the authors.
+ *
+ * Authors: Vaclav Petras (wenzeslaus gmail com)
+ *          Chris Jones (cjones1688 gmail com)
+ *          Anna Petrasova (kratochanna gmail com)
+ *          Zexi Chen (zchen22 ncsu edu)
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef POPS_RADIAL_KERNEL_HPP
+#define POPS_RADIAL_KERNEL_HPP
+
+#include "kernel_types.hpp"
+
+#include <cmath>
+#include <map>
+#include <tuple>
+#include <array>
+#include <random>
+#include <algorithm>
+#include <stdexcept>
+
+// PI is used in the code and M_PI is not guaranteed
+// fix it, but prefer the system definition
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+#ifndef PI
+#define PI M_PI
+#endif
+
+namespace pops {
+
+// we need to bring sqrt to the namespace
+// otherwise only candidates are raster-related
+using std::sqrt;
+
+/*! Von Mises Distribution (Circular data distribution)
+
+    mu is the mean angle, expressed in radians between 0 and 2*pi,
+    and kappa is the concentration parameter, which must be greater
+    than or equal to zero. If kappa is equal to zero, this distribution
+    reduces to a uniform random angle over the range 0 to 2*pi.
+*/
+class von_mises_distribution
+{
+public:
+    von_mises_distribution(double mu, double kappa)
+        : mu(mu), kappa(kappa), distribution(0.0, 1.0)
+    {}
+    template<class Generator>
+    double operator ()(Generator& generator)
+    {
+        double a, b, c, f, r, theta, u1, u2, u3, z;
+
+        if (kappa <= 1.e-06)
+            return 2 * PI * distribution(generator);
+
+        a = 1.0 + sqrt(1.0 + 4.0 * kappa * kappa);
+        b = (a - sqrt(2.0 * a)) / (2.0 * kappa);
+        r = (1.0 + b * b) / (2.0 * b);
+
+        while (true) {
+            u1 = distribution(generator);
+            z = cos(PI * u1);
+            f = (1.0 + r * z) / (r + z);
+            c = kappa * (r - f);
+            u2 = distribution(generator);
+            if (u2 <= c * (2.0 - c) || u2 < c * exp(1.0 - c))
+                break;
+        }
+
+        u3 = distribution(generator);
+        if (u3 > 0.5) {
+            theta = fmod(mu + acos(f), 2 * PI);
+        }
+        else {
+            theta = fmod(mu - acos(f), 2 * PI);
+        }
+        return theta;
+    }
+private:
+    double mu;
+    double kappa;
+    std::uniform_real_distribution<double> distribution;
+};
+
+/*! Spread direction
+ *
+ * Spread, typically wind, direction.
+ * Values are in degrees and are used in computations.
+ * `None` means that there is no wind.
+ */
+enum class Direction
+{
+    N = 0,  //!< North
+    NE = 45,  //!< Northeast
+    E = 90,  //!< NEast
+    SE = 135,  //!< Southeast
+    S = 180,  //!< South
+    SW = 225,  //!< Southwest
+    W = 270,  //!< West
+    NW = 315,  //!< Northwest
+    None  //!< No direction (non-directional)
+};
+
+/*! Get a corresponding enum value for a string which direction.
+ *
+ * Throws an std::invalid_argument exception if the values was not
+ * found or is not supported (which is the same thing).
+ */
+inline
+Direction direction_from_string(const std::string& text)
+{
+    std::map<std::string, Direction> mapping{
+        {"N", Direction::N},
+        {"NE", Direction::NE},
+        {"E", Direction::E},
+        {"SE", Direction::SE},
+        {"S", Direction::S},
+        {"SW", Direction::SW},
+        {"W", Direction::W},
+        {"NW", Direction::NW},
+        {"NONE", Direction::None},
+        {"None", Direction::None},
+        {"none", Direction::None},
+        {"", Direction::None}
+    };
+    try {
+        return mapping.at(text);
+    }
+    catch (const std::out_of_range&) {
+        throw std::invalid_argument("direction_from_string: Invalid"
+                                    " value '" + text +"' provided");
+    }
+}
+
+/*! Dispersal kernel providing all the radial kernels.
+ *
+ * We understand a radial kernel to be a kernel which has parameters
+ * which translate into a distance and direction.
+ *
+ * To add new kernel which fits with the other kernels supported by this
+ * class, add new member, its initialization from parameters,
+ * its implementation in the function call operator, and extend the
+ * supports_kernel() function.
+ */
+class RadialDispersalKernel
+{
+protected:
+    // the west-east resolution of the pixel
+    double east_west_resolution;
+    // the north-south resolution of the pixel
+    double north_south_resolution;
+    DispersalKernelType dispersal_kernel_type_;
+    std::cauchy_distribution<double> cauchy_distribution;
+    std::exponential_distribution<double> exponential_distribution;
+    von_mises_distribution von_mises;
+public:
+    RadialDispersalKernel(double ew_res, double ns_res,
+                          DispersalKernelType dispersal_kernel,
+                          double distance_scale,
+                          Direction dispersal_direction = Direction::None,
+                          double dispersal_direction_kappa = 0
+            )
+        :
+          east_west_resolution(ew_res),
+          north_south_resolution(ns_res),
+          dispersal_kernel_type_(dispersal_kernel),
+          // Here we initialize all distributions,
+          // although we won't use all of them.
+          cauchy_distribution(0.0, distance_scale),
+          exponential_distribution(distance_scale),
+          // if no wind, then kappa is 0
+          // TODO: change these two computations to standalone inline
+          // functions (dir to rad and adjust kappa)
+          von_mises(static_cast<int>(dispersal_direction) * PI / 180,
+                    dispersal_direction == Direction::None ? 0 : dispersal_direction_kappa)
+    {}
+
+    /*! Generates a new position for the spread.
+     *
+     * The randomness is based on the *generator*. The result may depend
+     * on previous calls of this operator (see e.g.
+     * `std::cauchy_distribution<RealType>::reset()`).
+     * Parameters *row* and *col* are row and column position of the
+     * current disperser. The generated position will be relative to it.
+     */
+    template<typename Generator>
+    std::tuple<int, int> operator() (Generator& generator, int row, int col)
+    {
+        double distance = 0;
+        double theta = 0;
+
+        // switch in between the supported kernels
+        // generate the distance from cauchy distribution or cauchy mixture distribution
+        if (dispersal_kernel_type_ == DispersalKernelType::Cauchy) {
+            distance = std::abs(cauchy_distribution(generator));
+        }
+        else if (dispersal_kernel_type_ == DispersalKernelType::Exponential) {
+            distance = std::abs(exponential_distribution(generator));
+        }
+        else {
+            // TODO: move this to constructor (fail fast)
+            // not all allowed kernels will/are supported by this class
+            throw std::invalid_argument("Unsupported dispersal kernel type");
+        }
+
+        theta = von_mises(generator);
+
+        row -= round(distance * cos(theta) / north_south_resolution);
+        col += round(distance * sin(theta) / east_west_resolution);
+
+        return std::make_tuple(row, col);
+    }
+
+    /*! Returns true if the kernel class support a given kernel type
+     *
+     * \warning This function is experimental and may be removed or
+     * changed at any time.
+     */
+    static bool supports_kernel(const DispersalKernelType type)
+    {
+        static const std::array<DispersalKernelType, 2> supports = {
+            DispersalKernelType::Cauchy,
+            DispersalKernelType::Exponential
+        };
+        auto it = std::find(supports.cbegin(), supports.cend(), type);
+        return it != supports.cend();
+    }
+};
+
+} // namespace pops
+
+#endif // POPS_RADIAL_KERNEL_HPP

--- a/short_long_kernel.hpp
+++ b/short_long_kernel.hpp
@@ -1,0 +1,107 @@
+/*
+ * PoPS model - disperal kernel combining short and long dispersals
+ *
+ * Copyright (C) 2015-2019 by the authors.
+ *
+ * Authors: Vaclav Petras (wenzeslaus gmail com)
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef POPS_SHORT_LONG_KERNEL_HPP
+#define POPS_SHORT_LONG_KERNEL_HPP
+
+#include "kernel_types.hpp"
+
+#include <tuple>
+#include <random>
+#include <type_traits>
+
+namespace pops {
+
+/*! Dispersal kernel template for short and long distance dispersal
+ *
+ * This class template can be used for switching between two kernels
+ * specified as template parameters where one kernel is assumed to
+ * be used short distance distance dispersal and the other for long
+ * distance one. The two disperal kernels can be the same or different.
+ *
+ * There are no assumptions for short or long kernels. We are using
+ * these names for clarity since this is how we expect the template
+ * to be used.
+ *
+ * Bernoulli distribution is used to decide between the short and
+ * long distance kernel. The long distance dispersal can be also
+ * competely disabled.
+ */
+template<typename ShortKernelType,
+         typename LongKernelType>
+class ShortLongDispersalKernel
+{
+protected:
+    bool use_long_kernel_;
+    ShortKernelType short_kernel_;
+    LongKernelType long_kernel_;
+    std::bernoulli_distribution bernoulli_distribution;
+
+public:
+    ShortLongDispersalKernel(const ShortKernelType& short_kernel,
+                             const LongKernelType& long_kernel,
+                             bool use_long_kernel,
+                             double percent_short_dispersal
+                             )
+        :
+          use_long_kernel_(use_long_kernel),
+          // Here we initialize all distributions,
+          // although we won't use all of them.
+          short_kernel_(short_kernel),
+          long_kernel_(long_kernel),
+          // use bernoulli distribution to act as the sampling with prob(gamma,1-gamma)
+          bernoulli_distribution(percent_short_dispersal)
+    {}
+
+    /*! \copydoc RadialDispersalKernel::operator()()
+     */
+    template<typename Generator>
+    std::tuple<int, int> operator() (Generator& generator, int row, int col)
+    {
+        // switch in between the supported kernels
+        if (!use_long_kernel_ || bernoulli_distribution(generator)) {
+            return short_kernel_(generator, row, col);
+        }
+        else {
+            return long_kernel_(generator, row, col);
+        }
+    }
+
+    /*! \copydoc RadialDispersalKernel::supports_kernel()
+     *
+     * Returns true if at least one of the kernels (short or long)
+     * supports the given kernel type.
+     *
+     * \note Note that if short and long kernels are different, this is
+     * not generally usable because one kernel can support that and the
+     * other not. However, there is not much room for accidental misuse
+     * of this because this class does not use the type directly
+     * (it is handled by the underlying kernels).
+     */
+    static bool supports_kernel(const DispersalKernelType type)
+    {
+        if (std::is_same<ShortKernelType, LongKernelType>::value) {
+            return ShortKernelType::supports_kernel(type);
+        }
+        else {
+            return ShortKernelType::supports_kernel(type) ||
+                    LongKernelType::supports_kernel(type);
+        }
+    }
+};
+
+} // namespace pops
+
+#endif // POPS_SHORT_LONG_KERNEL_HPP

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -23,84 +23,10 @@
 #include <tuple>
 #include <random>
 
-// PI is used in the code and M_PI is not guaranteed
-// fix it, but prefer the system definition
-#ifndef M_PI
-    #define M_PI 3.14159265358979323846
-#endif
-#ifndef PI
-    #define PI M_PI
-#endif
-
 using std::cerr;
 using std::endl;
 
 namespace pops {
-
-// we need to bring sqrt to the namespace
-// otherwise only candidates are raster-related
-using std::sqrt;
-
-/*! Von Mises Distribution (Circular data distribution)
-
-    mu is the mean angle, expressed in radians between 0 and 2*pi,
-    and kappa is the concentration parameter, which must be greater
-    than or equal to zero. If kappa is equal to zero, this distribution
-    reduces to a uniform random angle over the range 0 to 2*pi.
-*/
-class von_mises_distribution
-{
-public:
-    von_mises_distribution(double mu, double kappa)
-        : mu(mu), kappa(kappa), distribution(0.0, 1.0)
-    {}
-    template<class Generator>
-    double operator ()(Generator& generator)
-    {
-        double a, b, c, f, r, theta, u1, u2, u3, z;
-
-        if (kappa <= 1.e-06)
-            return 2 * PI * distribution(generator);
-
-        a = 1.0 + sqrt(1.0 + 4.0 * kappa * kappa);
-        b = (a - sqrt(2.0 * a)) / (2.0 * kappa);
-        r = (1.0 + b * b) / (2.0 * b);
-
-        while (true) {
-            u1 = distribution(generator);
-            z = cos(PI * u1);
-            f = (1.0 + r * z) / (r + z);
-            c = kappa * (r - f);
-            u2 = distribution(generator);
-            if (u2 <= c * (2.0 - c) || u2 < c * exp(1.0 - c))
-                break;
-        }
-
-        u3 = distribution(generator);
-        if (u3 > 0.5) {
-            theta = fmod(mu + acos(f), 2 * PI);
-        }
-        else {
-            theta = fmod(mu - acos(f), 2 * PI);
-        }
-        return theta;
-    }
-private:
-    double mu;
-    double kappa;
-    std::uniform_real_distribution<double> distribution;
-};
-
-enum DispersalKernel
-{
-    CAUCHY, CAUCHY_DOUBLE_SCALE
-};
-
-// NONE means that there is no wind
-enum Direction
-{
-    N = 0, NE = 45, E = 90, SE = 135, S = 180, SW = 225, W = 270, NW = 315, NONE
-};
 
 /*! The main class to control the spread simulation.
  *
@@ -124,20 +50,14 @@ class Simulation
 private:
     int width;
     int height;
-    // the west-east resolution of the pixel
-    int west_east_resolution;
-    // the north-south resolution of the pixel
-    int north_south_resolution;
     IntegerRaster dispersers;
     std::default_random_engine generator;
 public:
 
-    Simulation(unsigned random_seed, const IntegerRaster &size, double ew_res, double ns_res)
+    Simulation(unsigned random_seed, const IntegerRaster &size)
         :
           width(size.cols()),
           height(size.rows()),
-          west_east_resolution(ew_res),
-          north_south_resolution(ns_res),
           dispersers(height, width)
     {
         generator.seed(random_seed);
@@ -185,7 +105,7 @@ public:
             }
         }
     }
-    
+
     void generate(const IntegerRaster& infected,
                   bool weather, const FloatRaster& weather_coefficient,
                   double reproductive_rate)
@@ -211,58 +131,36 @@ public:
         }
     }
 
+    /** Creates dispersal locations for the dispersing individuals
+     *
+     * Assumes that the generate() function was called beforehand.
+     *
+     * DispersalKernel is callable object or function with one parameter
+     * which is the random number engine (generator). The return value
+     * is row and column in the raster (or outside of it). The current
+     * position is passed as parameters. The return valus is in the
+     * form of a tuple with row and column so that std::tie() is usable
+     * on the result, i.e. function returning
+     * `std::make_tuple(row, column)` fulfills this requirement.
+     */
+    template<typename DispersalKernel>
     void disperse(IntegerRaster& susceptible, IntegerRaster& infected,
                   IntegerRaster& mortality_tracker,
                   const IntegerRaster& total_plants,
                   std::vector<std::tuple<int, int>>& outside_dispersers,
                   bool weather, const FloatRaster& weather_coefficient,
-                  DispersalKernel dispersal_kernel, double short_distance_scale,
-                  double percent_short_distance_dispersal = 0.0,
-                  double long_distance_scale = 0.0,
-                  Direction wind_direction = NONE, double kappa = 2)
+                  DispersalKernel& dispersal_kernel)
     {
-        std::cauchy_distribution < double >distribution_cauchy_one(0.0, short_distance_scale);
-        std::cauchy_distribution < double >distribution_cauchy_two(0.0, long_distance_scale);
-    
-        std::bernoulli_distribution distribution_bern(percent_short_distance_dispersal);
-        std::uniform_real_distribution < double >distribution_uniform(0.0, 1.0);
-
-        if (wind_direction == NONE)
-            kappa = 0;
-        von_mises_distribution vonmisesvariate(wind_direction * PI / 180, kappa);
-
-        double distance = 0;
-        double theta = 0;
+        std::uniform_real_distribution<double> distribution_uniform(0.0, 1.0);
+        int row;
+        int col;
 
         for (int i = 0; i < height; i++) {
             for (int j = 0; j < width; j++) {
                 if (dispersers(i, j) > 0) {
                     for (int k = 0; k < dispersers(i, j); k++) {
 
-                        // generate the distance from cauchy distribution or cauchy mixture distribution
-                        if (dispersal_kernel == CAUCHY) {
-                            distance = abs(distribution_cauchy_one(generator));
-                        }
-                        else if (dispersal_kernel == CAUCHY_DOUBLE_SCALE) {
-                            // use bernoulli distribution to act as the sampling with prob(gamma,1-gamma)
-                            if (distribution_bern(generator)) {
-                                distance = abs(distribution_cauchy_one(generator));
-                            }
-                            else {
-                                distance = abs(distribution_cauchy_two(generator));
-                            }
-                        }
-                        else {
-                            cerr <<
-                                    "The paramter dispersal_kernel muse be set as either CAUCHY OR CAUCHY_DOUBLE_SCALE"
-                                 << endl;
-                            exit(EXIT_FAILURE);
-                        }
-
-                        theta = vonmisesvariate(generator);
-
-                        int row = i - round(distance * cos(theta) / north_south_resolution);
-                        int col = j + round(distance * sin(theta) / west_east_resolution);
+                        std::tie(row, col) = dispersal_kernel(generator, i, j);
 
                         if (row < 0 || row >= height || col < 0 || col >= width) {
                             // export dispersers dispersed outside of modeled area

--- a/switch_kernel.hpp
+++ b/switch_kernel.hpp
@@ -1,0 +1,81 @@
+/*
+ * PoPS model - disperal kernels
+ *
+ * Copyright (C) 2019 by the authors.
+ *
+ * Authors: Vaclav Petras (wenzeslaus gmail com)
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef POPS_SWITCH_KERNEL_HPP
+#define POPS_SWITCH_KERNEL_HPP
+
+#include "radial_kernel.hpp"
+#include "uniform_kernel.hpp"
+#include "kernel_types.hpp"
+
+namespace pops {
+
+/*! Dispersal kernel providing all the radial kernels.
+ *
+ * We understand a radial kernel to be a kernel which has parameters
+ * which translate into a distance and direction.
+ *
+ * To add new kernel, add new member, constructor parameter,
+ * its call in the function call operator, and extend the
+ * supports_kernel() function.
+ */
+class SwitchDispersalKernel
+{
+protected:
+    DispersalKernelType dispersal_kernel_type_;
+    RadialDispersalKernel radial_kernel_;
+    UniformDispersalKernel uniform_kernel_;
+
+public:
+    SwitchDispersalKernel(const DispersalKernelType& dispersal_kernel_type,
+                          const RadialDispersalKernel& radial_kernel,
+                          const UniformDispersalKernel& uniform_kernel
+                          )
+        :
+          dispersal_kernel_type_(dispersal_kernel_type),
+          // Here we initialize all kernels,
+          // although we won't use all of them.
+          radial_kernel_(radial_kernel),
+          uniform_kernel_(uniform_kernel)
+    {}
+
+    /*! \copydoc RadialDispersalKernel::operator()()
+     */
+    template<typename Generator>
+    std::tuple<int, int> operator() (Generator& generator, int row, int col)
+    {
+        // switch in between the supported kernels
+        if (dispersal_kernel_type_ == DispersalKernelType::Uniform) {
+            return uniform_kernel_(generator, row, col);
+        }
+        else {
+            return radial_kernel_(generator, row, col);
+        }
+    }
+
+    /*! \copydoc RadialDispersalKernel::supports_kernel()
+     */
+    static bool supports_kernel(const DispersalKernelType type)
+    {
+        if (type == DispersalKernelType::Uniform)
+            return true;
+        else
+            return RadialDispersalKernel::supports_kernel(type);
+    }
+};
+
+} // namespace pops
+
+#endif // POPS_SWITCH_KERNEL_HPP

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -3,7 +3,7 @@
 /*
  * Simple compilation test for the PoPS Simulation class.
  *
- * Copyright (C) 2018 by the authors.
+ * Copyright (C) 2018-2019 by the authors.
  *
  * Authors: Vaclav Petras <wenzeslaus gmail com>
  *
@@ -24,6 +24,7 @@
  */
 
 #include "raster.hpp"
+#include "radial_kernel.hpp"
 #include "simulation.hpp"
 
 #include <map>
@@ -50,20 +51,22 @@ int main()
     Raster<double> temperature = {{5, 0}, {0, 0}};
     Raster<double> weather_coefficient = {{0.6, 0.8}, {0.2, 0.8}};
     std::vector<std::tuple<int, int>> outside_dispersers;
-    DispersalKernel dispersal_kernel = CAUCHY;
+    DispersalKernelType dispersal_kernel = DispersalKernelType::Cauchy;
     bool weather = true;
     double lethal_temperature = -4.5;
     double reproductive_rate = 4.5;
     double short_distance_scale = 0.0;
     int ew_res = 30;
     int ns_res = 30;
-    Simulation<Raster<int>, Raster<double>> simulation(42, infected, ew_res, ns_res);
+    Simulation<Raster<int>, Raster<double>> simulation(42, infected);
     simulation.remove(infected, susceptible, temperature, lethal_temperature);
     simulation.generate(infected, weather, weather_coefficient, reproductive_rate);
+    RadialDispersalKernel kernel(ew_res, ns_res, dispersal_kernel,
+                                 short_distance_scale);
     simulation.disperse(susceptible, infected,
                         mortality_tracker, total_plants,
                         outside_dispersers, weather, weather_coefficient,
-                        dispersal_kernel, short_distance_scale);
+                        kernel);
     cout << outside_dispersers.size() << endl;
     return 0;
 }

--- a/uniform_kernel.hpp
+++ b/uniform_kernel.hpp
@@ -1,0 +1,75 @@
+/*
+ * PoPS model - random uniform dispersal kernel
+ *
+ * Copyright (C) 2015-2019 by the authors.
+ *
+ * Authors: Vaclav Petras (wenzeslaus gmail com)
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef POPS_UNIFORM_KERNEL_HPP
+#define POPS_UNIFORM_KERNEL_HPP
+
+#include "kernel_types.hpp"
+
+#include <random>
+
+namespace pops {
+
+/*! Dispersal kernel for random uniform dispersal over the whole
+ * landscape
+ *
+ * This class is a good example of how to write a kernel and
+ * it is useful for testing due to its simplicity. It tends to generate
+ * a lot of spread because it quickly spreads over the landscape.
+ * However, it may work as a good starting point for cases where no
+ * theory about the spread is available.
+ */
+class UniformDispersalKernel
+{
+protected:
+    int row_max_;
+    int col_max_;
+    std::uniform_int_distribution<> row_distribution;
+    std::uniform_int_distribution<> col_distribution;
+public:
+    UniformDispersalKernel(int row_max, int col_max)
+        :
+          row_max_(row_max),
+          col_max_(col_max),
+          row_distribution(0, row_max),
+          col_distribution(0, col_max)
+    {}
+
+    /*! \copybrief RadialDispersalKernel::operator()()
+     *
+     * The randomness is based on the *generator*.
+     * The new position does not depend on the position of the current
+     * disperser thus *row* and *col* are unused.
+     */
+    template<typename Generator>
+    std::tuple<int, int> operator() (Generator& generator, int row, int col)
+    {
+        row = row_distribution(generator);
+        col = col_distribution(generator);
+
+        return std::make_tuple(row, col);
+    }
+
+    /*! \copydoc RadialDispersalKernel::supports_kernel()
+     */
+    static bool supports_kernel(const DispersalKernelType type)
+    {
+        return type == DispersalKernelType::Uniform;
+    }
+};
+
+} // namespace pops
+
+#endif // POPS_UNIFORM_KERNEL_HPP


### PR DESCRIPTION
Each kernel or category of kernels is in its own class
including composite kernels which are switching between
different kernels based on parameters or random numbers.

The results are (slighly) different due to change from
wrong representation of resolution as int (now double)
and distance (double) using now the abs(double) function
instead of its integer (and thus inappropriate) version.

Fixes #26.