### PR TITLE
Allow combining doubles and ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project should be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2019-09-05 - Dispersal kernel rewrite
+
+### Added
+
+- More complete list of operators supported by Raster. (Vaclav Petras)
+- Rasters with different numerical types can be used in a single
+  expression (Vaclav Petras)
+
+### Changed
+
+- Binary operators for rasters are now function templates
+  instead of member functions (Vaclav Petras)
+
 ## 2019-08-11 - Dispersal kernel rewrite
 
 ### Added

--- a/test_raster.cpp
+++ b/test_raster.cpp
@@ -41,6 +41,7 @@ using std::endl;
 
 using pops::Raster;
 
+static
 void test_constructor_by_type()
 {
     Raster<int> a(10, 10);
@@ -48,6 +49,7 @@ void test_constructor_by_type()
     Raster<double> c(10, 10);
 }
 
+static
 void test_constructor_dimensions()
 {
     int x = 5;
@@ -64,6 +66,7 @@ void test_constructor_dimensions()
     std::cout << y << "x" << x << ":" << std::endl << b;
 }
 
+static
 void test_initializer_and_output()
 {
     Raster<int> a = {{1, 2},
@@ -77,6 +80,7 @@ void test_initializer_and_output()
     std::cout << "3x5:" << std::endl << b;
 }
 
+static
 void test_equal_operator()
 {
     Raster<int> a = {{1, 2}, {3, 4}, {5, 6}};
@@ -87,6 +91,7 @@ void test_equal_operator()
         std::cout << "Operator equal does not work" << std::endl;
 }
 
+static
 void test_not_equal_operator()
 {
     Raster<int> a = {{1, 2}, {3, 4}, {5, 6}};
@@ -97,14 +102,41 @@ void test_not_equal_operator()
         std::cout << "Operator not-equal does not work" << std::endl;
 }
 
-void test_plus_operator()
+static
+int test_plus_operator()
 {
     Raster<int> d = {{1, 2}, {3, 4}, {5, 6}};
     Raster<int> e = {{8, 9}, {10, 11}, {12, 13}};
-    auto f = d + e;
-    std::cout << f;
+    Raster<int> f = {{9, 11}, {13, 15}, {17, 19}};
+    if (d + e == f) {
+        std::cout << "Operator plus works" << std::endl;
+        return 0;
+    }
+    else {
+        std::cout << "Operator plus does not work" << std::endl;
+        return 1;
+    }
 }
 
+static
+int test_multiply_in_place_operator()
+{
+    Raster<double> d = {{1.1, 2}, {3.84, 4}, {5, 6}};
+    Raster<double> e = {{8, 9.5}, {10, 11}, {12, 13}};
+    Raster<double> f = e;
+    Raster<double> g = {{8.8, 19}, {38.4, 44}, {60, 78}};
+    d *= e;
+    if (e == f && d == g) {
+        std::cout << "Operator *= works" << std::endl;
+        return 0;
+    }
+    else {
+        std::cout << "Operator *= does not work" << std::endl;
+        return 1;
+    }
+}
+
+static
 void test_sqrt()
 {
     Raster<int> a = {{16, 25}, {4, 9}};
@@ -117,6 +149,67 @@ void test_sqrt()
         std::cout << "\n" << a << "!=\n" << b << std::endl;
 }
 
+template<typename T, typename U, typename V>
+static
+void test_diff_types_const()
+{
+    Raster<T> a = {{1, 2}, {3, 4}, {5, 6}};
+    Raster<U> b = {{1, 2}, {3, 4}, {5, 6}};
+    Raster<V> c = a + b;
+    c = a - b;
+    c = a * b;
+    c = a / b;
+}
+
+template<typename T, typename U>
+static
+void test_diff_types_modify()
+{
+    Raster<T> a = {{1, 2}, {3, 4}, {5, 6}};
+    Raster<U> b = {{1, 2}, {3, 4}, {5, 6}};
+    a += b;
+    a -= b;
+    a *= b;
+    a /= b;
+}
+
+template<typename T>
+static
+void test_op_int()
+{
+    Raster<T> a = {{1, 2}, {3, 4}, {5, 6}};
+    a += 1;
+    a -= 10;
+    a *= 6;
+    a /= 2;
+}
+
+template<typename T>
+static
+void test_op_double()
+{
+    Raster<T> a = {{1, 2}, {3, 4}, {5, 6}};
+    a += 1.1;
+    a -= 10.3;
+    a *= 7.5;
+    a /= 2.5;
+}
+
+template<typename T>
+static
+void test_op_order()
+{
+    Raster<T> a = {{1, 2}, {3, 4}, {5, 6}};
+    a + 1.1;
+    a - 10.3;
+    a * 75;
+    a / 25;
+    1 + a;
+    10 - a;
+    6.2 * a;
+    2.1 / a;
+}
+
 int main()
 {
     test_constructor_by_type();
@@ -124,7 +217,40 @@ int main()
     test_initializer_and_output();
     test_equal_operator();
     test_not_equal_operator();
+
+    test_plus_operator();
+    test_multiply_in_place_operator();
+
     test_sqrt();
+
+    // all doubles, no problem
+    test_diff_types_const<double, double, double>();
+    // operation on ints gives ints
+    test_diff_types_const<int, int, int>();
+    // combining int and double gives double
+    test_diff_types_const<double, int, double>();
+    test_diff_types_const<int, double, double>();
+    // undefined: we don't define promotion
+    // test_diff_types_const<int, int, double>();
+    // undefined: we don't allow demotion
+    // test_diff_types_const<double, double, int>();
+
+    // all doubles, no problem
+    test_diff_types_modify<double, double>();
+    // operation on ints gives ints
+    test_diff_types_modify<int, int>();
+    // operation on double gives double
+    test_diff_types_modify<double, int>();
+    // undefined: modifying int with double not allowed
+    // test_diff_types_modify<int, double>();
+
+    test_op_double<double>();
+    test_op_int<double>();
+    test_op_int<int>();
+    test_op_double<int>();
+
+    test_op_order<double>();
+    test_op_order<int>();
 
     return 0;
 }


### PR DESCRIPTION
Binary operators like plus are now function templates using public API (data()).
Operations returning a new raster return a common number type, so floating point
for operations where floating point was involved. Operations which modify the
raster and are using another floating point raster are not permitted.
This does not apply to computations with rasters and scalars which are
converted to a given type. No assignments and comparisons between
rasters of different type are supported.

Some missing operators were added for completeness. New tests added, older improved.