### PR TITLE
Support different scalar types explicitly

### DIFF
--- a/raster.hpp
+++ b/raster.hpp
@@ -73,6 +73,19 @@ BinaryOperation for_each_zip(InputIt1 first1, InputIt1 last1, InputIt2 first2, B
  * ```
  * row * total_number_of_columns + column
  * ```
+ *
+ * Operations involving raster and scalar preserve the type of the
+ * raster and don't produce a new type of raster based on the scalar
+ * type, i.e., `a * 0.5` where `a` is an integral raster type results
+ * in the same integral raster type, not floating point raster type.
+ * This makes perations such as `*` and `*=` behave the same for
+ * scalars.
+ *
+ * On the other hand, operations involving two rasters of different type
+ * resolve to their common type, specifically the common type of their
+ * scalars using `std::common_type`, i.e. `a * b` where `a` is an
+ * integral raster type and `b` is a floating raster type produce
+ * a floating raster type.
  */
 template<typename Number>
 class Raster
@@ -240,7 +253,8 @@ public:
         return *this;
     }
 
-    Raster operator+(Number value) const
+    template<typename OtherNumber>
+    Raster operator+(OtherNumber value) const
     {
         auto out = Raster(rows_, cols_);
 
@@ -249,7 +263,8 @@ public:
         return out;
     }
 
-    Raster operator-(Number value) const
+    template<typename OtherNumber>
+    Raster operator-(OtherNumber value) const
     {
         auto out = Raster(rows_, cols_);
 
@@ -258,7 +273,8 @@ public:
         return out;
     }
 
-    Raster operator*(Number value) const
+    template<typename OtherNumber>
+    Raster operator*(OtherNumber value) const
     {
         auto out = Raster(rows_, cols_);
 
@@ -267,7 +283,8 @@ public:
         return out;
     }
 
-    Raster operator/(Number value) const
+    template<typename OtherNumber>
+    Raster operator/(OtherNumber value) const
     {
         auto out = Raster(rows_, cols_);
 
@@ -276,28 +293,32 @@ public:
         return out;
     }
 
-    Raster& operator+=(Number value)
+    template<typename OtherNumber>
+    Raster& operator+=(OtherNumber value)
     {
         std::for_each(data_, data_ + (cols_ * rows_),
                       [&value](Number& a) { a += value; });
         return *this;
     }
 
-    Raster& operator-=(Number value)
+    template<typename OtherNumber>
+    Raster& operator-=(OtherNumber value)
     {
         std::for_each(data_, data_ + (cols_ * rows_),
                       [&value](Number& a) { a -= value; });
         return *this;
     }
 
-    Raster& operator*=(Number value)
+    template<typename OtherNumber>
+    Raster& operator*=(OtherNumber value)
     {
         std::for_each(data_, data_ + (cols_ * rows_),
                       [&value](Number& a) { a *= value; });
         return *this;
     }
 
-    Raster& operator/=(Number value)
+    template<typename OtherNumber>
+    Raster& operator/=(OtherNumber value)
     {
         std::for_each(data_, data_ + (cols_ * rows_),
                       [&value](Number& a) { a /= value; });

--- a/test_raster.cpp
+++ b/test_raster.cpp
@@ -210,6 +210,31 @@ void test_op_order()
     2.1 / a;
 }
 
+template<typename T>
+static
+int test_times_scalar()
+{
+    int errors = 0;
+    Raster<T> a = {{1, 2}, {3, 4}, {5, 6}};
+    auto b = a * 0.4;
+    T sum = 0;
+    b.for_each([&sum](T& v){sum += v;});
+    if (sum == 0) {
+        ++errors;
+        std::cout << "Operator 'raster * scalar' does not work" << std::endl;
+    }
+    a *= 0.4;
+    sum = 0;
+    a.for_each([&sum](T& v){sum += v;});
+    if (sum == 0) {
+        ++errors;
+        std::cout << "Operator 'raster *= scalar' does not work" << std::endl;
+    }
+    if (!errors)
+        std::cout << "Operators time for scalars OK" << std::endl;
+    return errors;
+}
+
 int main()
 {
     test_constructor_by_type();
@@ -251,6 +276,9 @@ int main()
 
     test_op_order<double>();
     test_op_order<int>();
+
+    test_times_scalar<int>();
+    test_times_scalar<double>();
 
     return 0;
 }


### PR DESCRIPTION
Operations such as * and / now (as well as + and - for consistency)
support arbitrary types. Thus the value is passed as is to
the actual scalar operator.

This fixes the problem when multiplication by double < 1
resulted in 0 because the value was converted to 0
in the function call to fit the operator (function)
parameter. The bug was introduced in 87eda93dc
by changing double to Number in these functions.
Now no conversion is done when not needed and
a proper conversion is done as part of the computation
when necessary.

Bahavior for multiplication of raster with scalar and two raster added.