### PR TITLE
Add non-owning constructor and Index parameter to Raster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project should be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2019-10-29 - More raster generalizations
+
+### Added
+
+- Raster can now hold data from some other object as long as the types
+  and layout match. (Vaclav Petras)
+- Raster Index and Number types exposed using typedefs.
+
+### Changed
+
+- Raster now has optional template parameter for the type of index used
+  in the class. (Vaclav Petras)
+
+### Fixed
+
+- Signed and unsigned types are no longer arbitrarily mixed in the
+  interface, e.g., `(int, int)` constructor is now `(Index, Index)`
+  being consistent with `cols()` and `rows()` functions. (Vaclav Petras)
+
 ## 2019-09-05 - Dispersal kernel rewrite
 
 ### Added

--- a/TECHNICALDEBT.md
+++ b/TECHNICALDEBT.md
@@ -17,6 +17,26 @@ issue which needs to be fixed (Fix).
 Entries should be removed when resolved. Issue from tracker can be
 optionally linked in an entry.
 
+## 2019-10-29 - More raster generalizations
+
+### Add
+
+- We use the same type for index and size in Raster. We need to
+  add size type parameter to allow for use of size_t and ssize_t
+  together which is needed to fully map other types to Raster.
+- Add container functions such `begin()` and `end()`.
+
+### Change
+
+- Use member initialization for all variables in all Raster constructors.
+- Binary operators of raster should be functions.
+  * Both scalar * raster and raster * scaler should be functions.
+
+### Fix
+
+- Add return code to raster class template test.
+- Resolve the `-Wsign-compare` warnings.
+
 ## 2019-08-11 - Dispersal kernel rewrite
 
 ### Add

--- a/test_raster.cpp
+++ b/test_raster.cpp
@@ -235,6 +235,76 @@ int test_times_scalar()
     return errors;
 }
 
+template<typename T, typename I>
+static
+int test_index()
+{
+    int errors = 0;
+    Raster<T, I> a = {{11, 12, 13, 14},
+                      {21, 22, 23, 24},
+                      {31, 32, 33, 34}};
+    I row = 0;
+    I col = 3;
+    if (a(row, col) != 14) {
+        std::cout << "Not reading the right value, but: " << a(row, col) << std::endl;
+        return ++errors;
+    }
+    T value = 20;
+    a(row, col) = value;
+    if (a(row, col) != value) {
+        std::cout << "Not reading the right value after assignment, but: " << a(row, col) << std::endl;
+        return ++errors;
+    }
+    if (!errors)
+        std::cout << "Index with custom template parameter value works" << std::endl;
+    return errors;
+}
+
+template<typename T, typename I>
+static
+int test_non_owner()
+{
+    int errors = 0;
+    const I rows = 3;
+    const I cols = 4;
+    T x[rows * cols] = {11, 12, 13, 14,
+                        21, 22, 23, 24,
+                        31, 32, 33, 34};
+    Raster<T> a(x, rows, cols);
+    I row = 2;
+    I col = 3;
+    if (a(row, col) != 34) {
+        std::cout << "Not reading from raster the value in array, but: " << a(row, col) << std::endl;
+        return ++errors;
+    }
+    T value = 40;
+    a(row, col) = value;
+    if (a(row, col) != value) {
+        std::cout << "Not reading from raster what was written, but: " << a(row, col) << std::endl;
+        return ++errors;
+    }
+    value = 50;
+    x[row * cols + col] = value;
+    if (a(row, col) != value) {
+        std::cout << "Not reading from array what was written, but: " << a(row, col) << std::endl;
+        return ++errors;
+    }
+    // no delete should be called here
+    a = {{100, 200}, {300, 400}};
+    a(1, 0) = 1000;
+    if (a(1, 0) != 1000) {
+        std::cout << "Not reading correctly after assignment, but: " << a(1, 0) << std::endl;
+        return ++errors;
+    }
+    if (x[cols] != 21) {
+        std::cout << "Array is broken, reading: " << x[cols] << std::endl;
+        return ++errors;
+    }
+    if (!errors)
+        std::cout << "Raster non-owning the data works" << std::endl;
+    return errors;
+}
+
 int main()
 {
     test_constructor_by_type();
@@ -279,6 +349,12 @@ int main()
 
     test_times_scalar<int>();
     test_times_scalar<double>();
+
+    test_index<int, int>();
+    test_index<int, unsigned>();
+    test_index<int, size_t>();
+
+    test_non_owner<int, size_t>();
 
     return 0;
 }


### PR DESCRIPTION
Raster can now use existing allocated memory (data) and does not take
its ownership.

The template allows now to customize the index/size used in the class.

These two features together allow for combining Raster with 3rd party storage
such as pybind11::buffer class.