### PR TITLE
Feature/pesticide

### DIFF
--- a/date.hpp
+++ b/date.hpp
@@ -69,17 +69,25 @@ public:
     inline friend bool operator!= (const Date &d1, const Date &d2);
 };
 
+/*!
+ * \brief Construct date from string
+ *
+ * Checks if months and days are in proper range
+ * (ignores Feb leap year), throws invalid_argument exception
+ *
+ * \param date in the format YYYY-MM-DD (or Y-M-D)
+ */
 Date::Date(std::string date)
 {
-    size_t pos = 0;
-    std::vector<int> vec;
-    while ((pos = date.find("-")) != std::string::npos) {
-        vec.push_back(std::stoi(date.substr(0, pos)));
-        date.erase(0, pos + 1);
-    }
-    year_ = vec.at(0);
-    month_ = vec.at(1);
+    size_t pos = date.find("-");
+    year_ = std::stoi(date.substr(0, pos));
+    date.erase(0, pos + 1);
+    pos = date.find("-");
+    month_ = std::stoi(date.substr(0, pos));
+    date.erase(0, pos + 1);
     day_ = std::stoi(date);
+    if (month_ <= 0 || month_ > 12 || day_> day_in_month[1][month_])
+        throw std::invalid_argument("Invalid date specified");
 }
 
 std::ostream& operator<<(std::ostream& os, const Date &d)
@@ -218,12 +226,12 @@ bool operator!= (const Date &d1, const Date &d2)
 }
 /*!
  * Increases the date by the num_days (specified by the user) except on
- * the last timestep of the year, which is increased by num_days 
+ * the last timestep of the year, which is increased by num_days
  * plus the number of  days left in the year that are less
  * than num_days (e.g. if the num_days = 28 the last time step is 29
  * or 30 (if leap year), if num_days = 23 that last time step is 43
- * or 44 (if leap year) days). This ensures that each year of the 
- * forecast starts on January 1st. 
+ * or 44 (if leap year) days). This ensures that each year of the
+ * forecast starts on January 1st.
  */
 void Date::increased_by_days(int num_days)
 {
@@ -263,7 +271,7 @@ void Date::increased_by_days(int num_days)
 /*!
  * Increases the date by one week (7 days) except on the last week
  * of the year, which is increased by 8 or 9 days if a leap year.
- * This ensures that each year of the forecast starts on January 1st. 
+ * This ensures that each year of the forecast starts on January 1st.
  */
 void Date::increased_by_week()
 {

--- a/date.hpp
+++ b/date.hpp
@@ -48,6 +48,10 @@ public:
     inline void increased_by_days(int num_days);
     inline void increased_by_week();
     inline void increased_by_month();
+    inline void add_day();
+    inline void add_days(unsigned n);
+    inline void subtract_day();
+    inline void subtract_days(unsigned n);
     inline Date get_year_end();
     inline Date get_next_year_end();
     inline Date get_last_day_of_week();
@@ -324,6 +328,53 @@ void Date::increased_by_month()
             day_ = day_in_month[0][month_];
         }
     }
+}
+/*!
+ * \brief Adds 1 day to a date
+ */
+void Date::add_day()
+{
+    day_++;
+    if (day_ > day_in_month[is_leap_year()][month_]) {
+        day_ = 1;
+        month_++;
+        if (month_ > 12) {
+            year_++;
+            month_ = 1;
+        }
+    }
+}
+/*!
+ * \brief Subtract 1 day from a date
+ */
+void Date::subtract_day()
+{
+    day_--;
+    if (day_ == 0) {
+        month_--;
+        if (month_ == 0) {
+            year_--;
+            month_ = 12;
+        }
+        day_ = day_in_month[is_leap_year()][month_];
+    }
+}
+/*!
+ * \brief Adds N days to a date
+ */
+void Date::add_days(unsigned n)
+{
+    for (unsigned i = 0; i < n; i++)
+        this->add_day();
+}
+
+/*!
+ * \brief Subtract N days from a date
+ */
+void Date::subtract_days(unsigned n)
+{
+    for (unsigned i = 0; i < n; i++)
+        this->subtract_day();
 }
 
 /*!

--- a/date.hpp
+++ b/date.hpp
@@ -20,6 +20,8 @@
 #define POPS_DATE_HPP
 
 #include <iostream>
+#include <string>
+#include <vector>
 
 namespace pops {
 
@@ -43,6 +45,7 @@ private:
 public:
     Date(const Date& d): year_(d.year_), month_(d.month_), day_(d.day_) {}
     Date(int y, int m, int d): year_(y), month_(m), day_(d) {}
+    Date(std::string date);
     inline void increased_by_days(int num_days);
     inline void increased_by_week();
     inline void increased_by_month();
@@ -65,6 +68,19 @@ public:
     inline friend bool operator== (const Date &d1, const Date &d2);
     inline friend bool operator!= (const Date &d1, const Date &d2);
 };
+
+Date::Date(std::string date)
+{
+    size_t pos = 0;
+    std::vector<int> vec;
+    while ((pos = date.find("-")) != std::string::npos) {
+        vec.push_back(std::stoi(date.substr(0, pos)));
+        date.erase(0, pos + 1);
+    }
+    year_ = vec.at(0);
+    month_ = vec.at(1);
+    day_ = std::stoi(date);
+}
 
 std::ostream& operator<<(std::ostream& os, const Date &d)
 {

--- a/date.hpp
+++ b/date.hpp
@@ -21,7 +21,6 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 
 namespace pops {
 

--- a/test_date.cpp
+++ b/test_date.cpp
@@ -96,7 +96,7 @@ int test_from_string()
 {
     int num_errors = 0;
     Date d = Date("2020-02-01");
-    if (d.year() != 2020 && d.month() != 2 && d.day() != 1) {
+    if (d.year() != 2020 || d.month() != 2 || d.day() != 1) {
         num_errors++;
         cout << d << endl;
     }
@@ -108,7 +108,43 @@ int test_from_string()
         d = Date("2016-04-31");
     }
     catch (std::invalid_argument) {}
-    if (d.year() != 2020 && d.month() != 2 && d.day() != 1) {
+    if (d.year() != 2020 || d.month() != 2 || d.day() != 1) {
+        num_errors++;
+        cout << d << endl;
+    }
+    return num_errors;
+}
+
+int test_add_days()
+{
+    int num_errors = 0;
+    Date d = Date("2000-02-28");
+    d.add_days(2);
+    if (d.month() != 3 || d.day() != 1) {
+        num_errors++;
+        cout << d << endl;
+    }
+    d = Date("2001-12-31");
+    d.add_days(366);
+    if (d.year() != 2003 || d.month() != 1 || d.day() != 1) {
+        num_errors++;
+        cout << d << endl;
+    }
+    return num_errors;
+}
+
+int test_subtract_days()
+{
+    int num_errors = 0;
+    Date d = Date("2000-03-01");
+    d.subtract_days(2);
+    if (d.month() != 2 || d.day() != 28) {
+        num_errors++;
+        cout << d << endl;
+    }
+    d = Date("2002-01-01");
+    d.subtract_days(366);
+    if (d.year() != 2000 || d.month() != 12 || d.day() != 31) {
         num_errors++;
         cout << d << endl;
     }
@@ -122,6 +158,8 @@ int main()
     test_years_by_month();
     num_errors += test_last_day_of_step();
     num_errors += test_from_string();
+    num_errors += test_add_days();
+    num_errors += test_subtract_days();
     cout << "Test Date class: number of errors: " << num_errors << endl;
 
     return 0;

--- a/test_date.cpp
+++ b/test_date.cpp
@@ -91,12 +91,37 @@ int test_last_day_of_step()
     }
     return num_errors;
 }
+
+int test_from_string()
+{
+    int num_errors = 0;
+    Date d = Date("2020-02-01");
+    if (d.year() != 2020 && d.month() != 2 && d.day() != 1) {
+        num_errors++;
+        cout << d << endl;
+    }
+    try {
+        d = Date("2015-31-01");
+    }
+    catch (std::invalid_argument) {}
+    try {
+        d = Date("2016-04-31");
+    }
+    catch (std::invalid_argument) {}
+    if (d.year() != 2020 && d.month() != 2 && d.day() != 1) {
+        num_errors++;
+        cout << d << endl;
+    }
+    return num_errors;
+}
+
 int main()
 {
     int num_errors = 0;
     // Test of date computations for SOD model
     test_years_by_month();
     num_errors += test_last_day_of_step();
+    num_errors += test_from_string();
     cout << "Test Date class: number of errors: " << num_errors << endl;
 
     return 0;

--- a/test_treatments.cpp
+++ b/test_treatments.cpp
@@ -30,27 +30,21 @@
 
 using namespace pops;
 
-int test_ratio()
+
+int test_application_ratio()
 {
     int num_errors = 0;
-    Treatments<Raster<int>, Raster<double>> treatments(TreatmentApplication::Ratio);
+    Treatments<Raster<int>, Raster<double>> treatments;
     Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
-    Raster<double> tr2 = {{0, 0.5}, {0, 0.25}};
-    Raster<double> tr3 = {{0, 0}, {1, 0}};
     Raster<int> susceptible = {{10, 6}, {20, 42}};
+    Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    treatments.add_treatment(2000, tr1);
-    treatments.add_treatment(2001, tr2);
-    treatments.add_treatment(2002, tr3);
-    treatments.apply_treatment_host(2000, infected, susceptible);
-    treatments.apply_treatment_infected(2001, infected);
+    treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::Ratio);
+    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 3}, {5, 42}};
-    Raster<int> inf_treated = {{0, 1}, {4, 30}};
-    if (susceptible == treated && infected == inf_treated) {
-        std::cout << "Treatment with ratio app works" << std::endl;
-    }
-    else {
+    Raster<int> inf_treated = {{0, 2}, {4, 40}};
+    if (!(susceptible == treated && infected == inf_treated)) {
         std::cout << "Treatment with ratio app does not work" << std::endl;
         std::cout << susceptible << infected;
         num_errors++;
@@ -58,29 +52,254 @@ int test_ratio()
     return num_errors;
 }
 
-int test_all_infected()
+int test_application_all_inf()
 {
     int num_errors = 0;
-    Treatments<Raster<int>, Raster<double>> treatments(TreatmentApplication::AllInfectedInCell);
+    Treatments<Raster<int>, Raster<double>> treatments;
     Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
-    Raster<double> tr2 = {{0, 0.5}, {0, 0.25}};
-    Raster<double> tr3 = {{0, 0}, {1, 0}};
     Raster<int> susceptible = {{10, 6}, {20, 42}};
+    Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    treatments.add_treatment(2000, tr1);
-    treatments.add_treatment(2001, tr2);
-    treatments.add_treatment(2002, tr3);
-    treatments.apply_treatment_host(2000, infected, susceptible);
-    treatments.apply_treatment_infected(2001, infected);
+    treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::AllInfectedInCell);
+    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 3}, {5, 42}};
-    Raster<int> inf_treated = {{0, 0}, {0, 0}};
-    if (susceptible == treated && infected == inf_treated) {
-        std::cout << "Treatment with all infected works" << std::endl;
-    }
-    else {
-        std::cout << "Treatment with all infected does not work" << std::endl;
+    Raster<int> inf_treated = {{0, 0}, {0, 40}};
+    if (!(susceptible == treated && infected == inf_treated)) {
+        std::cout << "Treatment with AllInfectedInCell app does not work" << std::endl;
         std::cout << susceptible << infected;
+        num_errors++;
+    }
+    return num_errors;
+}
+
+int test_application_ratio_pesticide()
+{
+    int num_errors = 0;
+    Treatments<Raster<int>, Raster<double>> treatments;
+    Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
+    Raster<int> susceptible = {{10, 6}, {20, 42}};
+    Raster<int> resistant = {{0, 0}, {0, 0}};
+    Raster<int> infected = {{1, 4}, {16, 40}};
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::Ratio);
+    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+
+    Raster<int> treated = {{10, 6}, {20, 42}};
+    Raster<int> inf_treated = {{1, 4}, {16, 40}};
+    Raster<int> resist = {{0, 0}, {0, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Treatment with pesticide and ratio app does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
+
+    treated = {{0, 3}, {5, 42}};
+    inf_treated = {{0, 2}, {4, 40}};
+    resist = {{11, 5}, {27, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Treatment with pesticide and ratio app does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    treatments.manage(Date(2020, 5, 8), infected, susceptible, resistant);
+
+    treated = {{11, 8}, {32, 42}};
+    resist = {{0, 0}, {0, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Treatment with pesticide and ratio app does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    return num_errors;
+}
+
+
+int test_application_all_inf_pesticide()
+{
+    int num_errors = 0;
+    Treatments<Raster<int>, Raster<double>> treatments;
+    Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
+    Raster<int> susceptible = {{10, 6}, {20, 42}};
+    Raster<int> resistant = {{0, 0}, {0, 0}};
+    Raster<int> infected = {{1, 4}, {16, 40}};
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::AllInfectedInCell);
+    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+
+    Raster<int> treated = {{10, 6}, {20, 42}};
+    Raster<int> inf_treated = {{1, 4}, {16, 40}};
+    Raster<int> resist = {{0, 0}, {0, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Treatment with pesticide and AllInfectedInCell app does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
+
+    treated = {{0, 3}, {5, 42}};
+    inf_treated = {{0, 0}, {0, 40}};
+    resist = {{11, 7}, {31, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Treatment with pesticide and AllInfectedInCell app does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    treatments.manage(Date(2020, 5, 8), infected, susceptible, resistant);
+
+    treated = {{11, 10}, {36, 42}};
+    resist = {{0, 0}, {0, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Treatment with pesticide and AllInfectedInCell app does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    return num_errors;
+}
+
+
+int test_combination()
+{
+    int num_errors = 0;
+    Treatments<Raster<int>, Raster<double>> treatments;
+    Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
+    Raster<double> tr2 = {{1, 1}, {1, 1}};
+
+    Raster<int> susceptible = {{10, 6}, {20, 42}};
+    Raster<int> resistant = {{0, 0}, {0, 0}};
+    Raster<int> infected = {{1, 4}, {16, 40}};
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
+    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
+    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+
+    Raster<int> treated = {{10, 6}, {20, 42}};
+    Raster<int> inf_treated = {{1, 4}, {16, 40}};
+    Raster<int> resist = {{0, 0}, {0, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Combination of treatments does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
+
+    treated = {{0, 3}, {5, 42}};
+    inf_treated = {{0, 2}, {4, 40}};
+    resist = {{0, 0}, {0, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Combination of treatments does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    treatments.manage(Date(2020, 6, 3), infected, susceptible, resistant);
+
+    treated = {{0, 0}, {0, 0}};
+    inf_treated = {{0, 0}, {0, 0}};
+    resist = {{0, 5}, {9, 82}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Combination of treatments does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
+
+    treated = {{0, 5}, {9, 82}};
+    inf_treated = {{0, 0}, {0, 0}};
+    resist = {{0, 0}, {0, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Combination of treatments does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    return num_errors;
+}
+
+int test_steering()
+{
+    int num_errors = 0;
+    Treatments<Raster<int>, Raster<double>> treatments;
+    Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
+    Raster<double> tr2 = {{1, 1}, {1, 1}};
+
+    Raster<int> susceptible = {{10, 6}, {20, 42}};
+    Raster<int> resistant = {{0, 0}, {0, 0}};
+    Raster<int> infected = {{1, 4}, {16, 40}};
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
+    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
+    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 5, 12), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 6, 1), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 6, 3), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 6, 10), infected, susceptible, resistant);
+
+    Raster<int> treated = {{0, 5}, {9, 82}};
+    Raster<int> inf_treated = {{0, 0}, {0, 0}};
+    Raster<int> resist = {{0, 0}, {0, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Combination of treatments does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+
+    susceptible = {{10, 6}, {20, 42}};
+    resistant = {{0, 0}, {0, 0}};
+    infected = {{1, 4}, {16, 40}};
+    treatments.reset(Date(2020, 1, 1));
+    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 5, 12), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 6, 1), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 6, 3), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 6, 10), infected, susceptible, resistant);
+
+    treated = {{0, 5}, {9, 82}};
+    inf_treated = {{0, 0}, {0, 0}};
+    resist = {{0, 0}, {0, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Combination of treatments does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+
+    return num_errors;
+}
+
+int test_clear()
+{
+    int num_errors = 0;
+    int num_actions = 0;
+    Treatments<Raster<int>, Raster<double>> treatments;
+    Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
+    Raster<double> tr2 = {{1, 1}, {1, 1}};
+    Raster<double> tr3 = {{1, 0}, {1, 0}};
+
+    Raster<int> susceptible = {{10, 6}, {20, 42}};
+    Raster<int> resistant = {{0, 0}, {0, 0}};
+    Raster<int> infected = {{1, 4}, {16, 40}};
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
+    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
+    treatments.add_treatment(tr2, Date(2020, 6, 8), 7, TreatmentApplication::Ratio);
+    treatments.clear_after_date(Date(2020, 6, 1));
+    num_actions += treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+    num_actions += treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
+    num_actions += treatments.manage(Date(2020, 5, 12), infected, susceptible, resistant);
+    num_actions += treatments.manage(Date(2020, 6, 1), infected, susceptible, resistant);
+    num_actions += treatments.manage(Date(2020, 6, 3), infected, susceptible, resistant);
+    num_actions += treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
+    num_actions += treatments.manage(Date(2020, 6, 10), infected, susceptible, resistant);
+
+    Raster<int> treated = {{0, 5}, {9, 82}};
+    Raster<int> inf_treated = {{0, 0}, {0, 0}};
+    Raster<int> resist = {{0, 0}, {0, 0}};
+    if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
+        std::cout << "Clearing of treatments does not work" << std::endl;
+        std::cout << susceptible << infected << resistant;
+        num_errors++;
+    }
+    if (num_actions != 3) {
+        std::cout << "Clearing of treatments does not work" << std::endl;
+        std::cout << num_actions << std::endl;
         num_errors++;
     }
     return num_errors;
@@ -90,30 +309,13 @@ int main()
 {
     int num_errors = 0;
 
-    Treatments<Raster<int>, Raster<double>> treatments;
-    treatments.clear_all();
-    Raster<double> tr1 = {{1, 0}, {0, 0}};
-    Raster<double> tr2 = {{0, 1}, {0, 0}};
-    Raster<double> tr3 = {{0, 0}, {1, 0}};
-    Raster<int> susceptible = {{10, 6}, {14, 15}};
-    Raster<int> infected = {{1, 2}, {1, 1}};
-    treatments.add_treatment(2000, tr1);
-    treatments.add_treatment(2001, tr2);
-    treatments.add_treatment(2002, tr3);
-    treatments.apply_treatment_host(2000, infected, susceptible);
-    treatments.apply_treatment_infected(2001, infected);
-
-    Raster<int> treated = {{0, 6}, {14, 15}};
-    Raster<int> inf_treated = {{0, 0}, {1, 1}};
-    if (susceptible == treated && infected == inf_treated)
-        std::cout << "Treatment with default app works" << std::endl;
-    else
-        std::cout << "Treatment with default app does not work" << std::endl;
-
-    treatments.clear_after_year(2001);
-
-    num_errors += test_ratio();
-    num_errors += test_all_infected();
+    num_errors += test_application_ratio();
+    num_errors += test_application_all_inf();
+    num_errors += test_application_ratio_pesticide();
+    num_errors += test_application_all_inf_pesticide();
+    num_errors += test_combination();
+    num_errors += test_steering();
+    num_errors += test_clear();
 
     return num_errors;
 }

--- a/test_treatments.cpp
+++ b/test_treatments.cpp
@@ -26,6 +26,7 @@
 
 #include "raster.hpp"
 #include "treatments.hpp"
+#include "date.hpp"
 
 
 using namespace pops;
@@ -39,7 +40,8 @@ int test_application_ratio()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::Ratio);
+    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
+    treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::Ratio, increase_by_step);
     treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 3}, {5, 42}};
@@ -60,7 +62,8 @@ int test_application_all_inf()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::AllInfectedInCell);
+    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
+    treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::AllInfectedInCell, increase_by_step);
     treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 3}, {5, 42}};
@@ -81,7 +84,8 @@ int test_application_ratio_pesticide()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::Ratio);
+    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::Ratio, increase_by_step);
     treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
 
     Raster<int> treated = {{10, 6}, {20, 42}};
@@ -123,7 +127,8 @@ int test_application_all_inf_pesticide()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::AllInfectedInCell);
+    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::AllInfectedInCell, increase_by_step);
     treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
 
     Raster<int> treated = {{10, 6}, {20, 42}};
@@ -167,8 +172,9 @@ int test_combination()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
-    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
+    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio, increase_by_step);
+    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio, increase_by_step);
     treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
 
     Raster<int> treated = {{10, 6}, {20, 42}};
@@ -222,21 +228,21 @@ int test_steering()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
-    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
+    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio, increase_by_step);
+    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio, increase_by_step);
     treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
     treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
     treatments.manage(Date(2020, 5, 12), infected, susceptible, resistant);
     treatments.manage(Date(2020, 6, 1), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 6, 3), infected, susceptible, resistant);
     treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 6, 10), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 6, 15), infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 5}, {9, 82}};
     Raster<int> inf_treated = {{0, 0}, {0, 0}};
     Raster<int> resist = {{0, 0}, {0, 0}};
     if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
-        std::cout << "Combination of treatments does not work" << std::endl;
+        std::cout << "Steering with treatments does not work" << std::endl;
         std::cout << susceptible << infected << resistant;
         num_errors++;
     }
@@ -244,20 +250,18 @@ int test_steering()
     susceptible = {{10, 6}, {20, 42}};
     resistant = {{0, 0}, {0, 0}};
     infected = {{1, 4}, {16, 40}};
-    treatments.reset(Date(2020, 1, 1));
     treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
     treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
     treatments.manage(Date(2020, 5, 12), infected, susceptible, resistant);
     treatments.manage(Date(2020, 6, 1), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 6, 3), infected, susceptible, resistant);
     treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 6, 10), infected, susceptible, resistant);
+    treatments.manage(Date(2020, 6, 15), infected, susceptible, resistant);
 
     treated = {{0, 5}, {9, 82}};
     inf_treated = {{0, 0}, {0, 0}};
     resist = {{0, 0}, {0, 0}};
     if (!(susceptible == treated && infected == inf_treated && resist == resistant)) {
-        std::cout << "Combination of treatments does not work" << std::endl;
+        std::cout << "Steering with treatments does not work" << std::endl;
         std::cout << susceptible << infected << resistant;
         num_errors++;
     }
@@ -277,17 +281,17 @@ int test_clear()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
-    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
-    treatments.add_treatment(tr2, Date(2020, 6, 8), 7, TreatmentApplication::Ratio);
+    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio, increase_by_step);
+    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio, increase_by_step);
+    treatments.add_treatment(tr3, Date(2020, 6, 8), 7, TreatmentApplication::Ratio, increase_by_step);
     treatments.clear_after_date(Date(2020, 6, 1));
     num_actions += treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
     num_actions += treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
     num_actions += treatments.manage(Date(2020, 5, 12), infected, susceptible, resistant);
     num_actions += treatments.manage(Date(2020, 6, 1), infected, susceptible, resistant);
-    num_actions += treatments.manage(Date(2020, 6, 3), infected, susceptible, resistant);
     num_actions += treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
-    num_actions += treatments.manage(Date(2020, 6, 10), infected, susceptible, resistant);
+    num_actions += treatments.manage(Date(2020, 6, 15), infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 5}, {9, 82}};
     Raster<int> inf_treated = {{0, 0}, {0, 0}};

--- a/treatments.hpp
+++ b/treatments.hpp
@@ -27,149 +27,53 @@ namespace pops {
 
 
 /**
- * @brief The enum to decide how threatment is applied
+ * @brief The enum to decide how treatment is applied
  */
 enum class TreatmentApplication {
     Ratio,  ///< A ratio is applied to all treated rasters
     AllInfectedInCell  ///< All infected individuals are removed, rest by ratio
 };
 
-template<typename IntegerRaster, typename FloatRaster>
-class Treatments
-{
-private:
-    std::map<int, FloatRaster> treatments;
-    TreatmentApplication application;
-public:
-    Treatments(
-        TreatmentApplication treatment_application = TreatmentApplication::Ratio) :
-        application(treatment_application)
-    {}
-    void add_treatment(int year, const FloatRaster &map)
-    {
-        treatments[year] = map;
-    }
-    void clear_all()
-    {
-        treatments.erase(treatments.begin(), treatments.end());
-    }
-    void clear_after_year(int year)
-    {
-        for (auto it = treatments.begin(); it != treatments.end();) {
-            if (it->first > year) {
-                treatments.erase(it++);
-            }
-            else {
-                ++it;
-            }
-        }
-    }
-    void apply_treatment_host(int year, IntegerRaster &infected, IntegerRaster &susceptible)
-    {
-        // this expression fails in rcpp
-        // host = host - (host * treatments[year]);
-        if (treatments.find(year) != treatments.end()) {
-            for(unsigned i = 0; i < infected.rows(); i++)
-                for(unsigned j = 0; j < infected.cols(); j++) {
-                    if (application == TreatmentApplication::Ratio) {
-                        infected(i, j) = infected(i, j) - (infected(i, j) * treatments[year](i, j));
-                        susceptible(i, j) = susceptible(i, j) - (susceptible(i, j) * treatments[year](i, j));
-                    }
-                    else if (application == TreatmentApplication::AllInfectedInCell) {
-                        infected(i, j) = treatments[year](i, j) ? 0 : infected(i, j);
-                        susceptible(i, j) = susceptible(i, j) - (susceptible(i, j) * treatments[year](i, j));
-                    }
-                }
-        }
-        // otherwise no treatment for that year
-    }
-    void apply_treatment_infected(int year, IntegerRaster &infected)
-    {
-        if (treatments.find(year) != treatments.end()) {
-            for(unsigned i = 0; i < infected.rows(); i++)
-                for(unsigned j = 0; j < infected.cols(); j++)
-                    if (application == TreatmentApplication::Ratio) {
-                        infected(i, j) = infected(i, j) - (infected(i, j) * treatments[year](i, j));
-                    }
-                    else if (application == TreatmentApplication::AllInfectedInCell) {
-                        infected(i, j) = treatments[year](i, j) ? 0 : infected(i, j);
-                    }
-        }
-    }
-};
 
 template<typename IntegerRaster, typename FloatRaster>
-class PesticideTreatment
+class AbstractTreatment
 {
-private:
+public:
+    virtual Date get_start() = 0;
+    virtual Date get_end() = 0;
+    virtual void reset(const Date& date) = 0;
+    virtual bool should_start(const Date& date) = 0;
+    virtual bool should_end(const Date& date) = 0;
+    virtual bool should_apply_mortality() = 0;
+    virtual void apply_treatment(IntegerRaster& infected, IntegerRaster& susceptible, IntegerRaster& resistant) = 0;
+    virtual void end_treatment(IntegerRaster& susceptible, IntegerRaster& resistant) = 0;
+    virtual void apply_treatment_mortality(IntegerRaster& infected) = 0;
+    virtual ~AbstractTreatment() {}
+};
+
+
+template<typename IntegerRaster, typename FloatRaster>
+class BaseTreatment : public AbstractTreatment<IntegerRaster, FloatRaster>
+{
+protected:
     Date start;
     Date end;
-    bool resistant;
+    bool active;
     bool apply_mortality;
     FloatRaster map;
     TreatmentApplication application;
 public:
-    Treatment(const FloatRaster &map, const Date &start, int num_days,
-              TreatmentApplication treatment_application):
-        map(map), start(start), resistant(false), apply_mortality(false), application(treatment_application)
-    {
-        Date end_date = Date(start);
-        end_date.increased_by_days(num_days);
-    }
-    Treatment() = delete;
-
-    bool should_start(const Date &date)
-    {
-        if (!resistant && date >= start && date < end)
-            return true;
-        return false;
-    }
-    bool should_end(const Date &date)
-    {
-        if (resistant && date >= end)
-            return true;
-        return false;
-    }
-    bool should_apply_mortality()
+    BaseTreatment(const FloatRaster& map, const Date& start,
+                  TreatmentApplication treatment_application):
+        start(start), end(start), active(false), apply_mortality(false), map(map), application(treatment_application)
+    {}
+    Date get_start() {return start;}
+    Date get_end() {return end;}
+    bool should_apply_mortality() override
     {
         return apply_mortality;
     }
-
-    void reset_resistance(){
-        resistant = false;
-    }
-
-    void apply_treatment(IntegerRaster &infected, IntegerRaster &susceptible, IntegerRaster &resistant)
-    {
-        for(unsigned i = 0; i < infected.rows(); i++)
-            for(unsigned j = 0; j < infected.cols(); j++) {
-                int infected_resistant;
-                int susceptible_resistant = susceptible(i, j) * map(i, j);
-                if (application == TreatmentApplication::Ratio) {
-                    infected_resistant = infected(i, j) * map(i, j);
-                }
-                else if (application == TreatmentApplication::AllInfectedInCell) {
-                    infected_resistant = map(i, j) ? infected(i, j): 0;
-                }
-                infected(i, j) -= infected_resistant;
-                resistant(i, j) = infected_resistant + susceptible_resistant;
-                susceptible(i, j) -= susceptible_resistant;
-            }
-        resistant = true;
-        apply_mortality = true;
-    }
-    void end_treatment(IntegerRaster &susceptible, IntegerRaster &resistant)
-    {
-        for(unsigned i = 0; i < resistant.rows(); i++)
-            for(unsigned j = 0; j < resistant.cols(); j++) {
-                if (map(i, j) > 0){
-                    susceptible(i, j) += resistant(i, j);
-                    resistant(i, j) = 0;
-                }
-            }
-        resistant = false;
-    }
-    void apply_treatment_mortality(IntegerRaster &infected)
+    void apply_treatment_mortality(IntegerRaster& infected) override
     {
         for(unsigned i = 0; i < infected.rows(); i++)
             for(unsigned j = 0; j < infected.cols(); j++) {
@@ -186,57 +90,176 @@ public:
 
 
 template<typename IntegerRaster, typename FloatRaster>
-class PesticideTreatments
+class SimpleTreatment : public BaseTreatment<IntegerRaster, FloatRaster>
+{
+public:
+    SimpleTreatment(const FloatRaster& map, const Date& start,
+                    TreatmentApplication treatment_application):
+        BaseTreatment<IntegerRaster, FloatRaster>(map, start, treatment_application)
+    {}
+    bool should_start(const Date& date) override
+    {
+        if (!this->active && date >= this->start)
+            return true;
+        return false;
+    }
+    bool should_end(const Date&) override
+    {
+        return false;
+    }
+    void reset(const Date& date) override {
+        if (this->get_start() >= date)
+            this->active = false;
+    }
+    void apply_treatment(IntegerRaster& infected, IntegerRaster& susceptible, IntegerRaster& ) override
+    {
+        for(unsigned i = 0; i < infected.rows(); i++)
+            for(unsigned j = 0; j < infected.cols(); j++) {
+                if (this->application == TreatmentApplication::Ratio) {
+                    infected(i, j) = infected(i, j) - (infected(i, j) * this->map(i, j));
+                }
+                else if (this->application == TreatmentApplication::AllInfectedInCell) {
+                    infected(i, j) = this->map(i, j) ? 0 : infected(i, j);
+                }
+                susceptible(i, j) = susceptible(i, j) - (susceptible(i, j) * this->map(i, j));
+            }
+        this->active = true;
+    }
+    void end_treatment(IntegerRaster&, IntegerRaster&) override
+    {
+        return;
+    }
+};
+
+
+template<typename IntegerRaster, typename FloatRaster>
+class PesticideTreatment : public BaseTreatment<IntegerRaster, FloatRaster>
+{
+public:
+    PesticideTreatment(const FloatRaster& map, const Date& start, int num_days,
+                       TreatmentApplication treatment_application):
+        BaseTreatment<IntegerRaster, FloatRaster>(map, start, treatment_application)
+    {
+        this->end.increased_by_days(num_days);
+    }
+    bool should_start(const Date& date) override
+    {
+        if (!this->active && date >= this->start && date < this->end)
+            return true;
+        return false;
+    }
+    bool should_end(const Date& date) override
+    {
+        if (this->active && date >= this->end)
+            return true;
+        return false;
+    }
+    void reset(const Date&) override {
+        this->active = false;
+    }
+    void apply_treatment(IntegerRaster& infected, IntegerRaster& susceptible, IntegerRaster& resistant) override
+    {
+        for(unsigned i = 0; i < infected.rows(); i++)
+            for(unsigned j = 0; j < infected.cols(); j++) {
+                int infected_resistant;
+                int susceptible_resistant = susceptible(i, j) * this->map(i, j);
+                if (this->application == TreatmentApplication::Ratio) {
+                    infected_resistant = infected(i, j) * this->map(i, j);
+                }
+                else if (this->application == TreatmentApplication::AllInfectedInCell) {
+                    infected_resistant = this->map(i, j) ? infected(i, j): 0;
+                }
+                infected(i, j) -= infected_resistant;
+                resistant(i, j) = infected_resistant + susceptible_resistant;
+                susceptible(i, j) -= susceptible_resistant;
+            }
+        this->active = true;
+        this->apply_mortality = true;
+    }
+    void end_treatment(IntegerRaster& susceptible, IntegerRaster& resistant) override
+    {
+        for(unsigned i = 0; i < resistant.rows(); i++)
+            for(unsigned j = 0; j < resistant.cols(); j++) {
+                if (this->map(i, j) > 0){
+                    susceptible(i, j) += resistant(i, j);
+                    resistant(i, j) = 0;
+                }
+            }
+        this->active = false;
+    }
+};
+
+
+template<typename IntegerRaster, typename FloatRaster>
+class Treatments
 {
 private:
-    std::vector<PesticideTreatment<IntegerRaster, FloatRaster>> treatments;
-    TreatmentApplication application;
-
+    std::vector<AbstractTreatment<IntegerRaster, FloatRaster>*> treatments;
 public:
-    PesticideTreatments(TreatmentApplication treatment_application = TreatmentApplication::Ratio) :
-        application(treatment_application)
-    {}
-    void add_treatment(const FloatRaster &map, const Date &start_date, int num_days)
+    ~Treatments()
     {
-        treatments.emplace_back(map, start_date, num_days, application);
+        for (auto item : treatments)
+        {
+            delete item;
+        }
     }
-    /* this needs to be called when going back
-       when doing computational steering */
-    void reset_resistance()
+    void add_treatment(const FloatRaster& map, const Date& start_date, int num_days, TreatmentApplication treatment_application)
     {
-        for (unsigned i = 0; i < treatments.size(); i++)
-            treatments[i].reset_resistance();
+        if (num_days == 0)
+            treatments.push_back(new SimpleTreatment<IntegerRaster, FloatRaster>(map, start_date, treatment_application));
+        else
+            treatments.push_back(new PesticideTreatment<IntegerRaster, FloatRaster>(map, start_date, num_days, treatment_application));
     }
-
-    bool pesticide_management(const Date &current, IntegerRaster &infected,
-                              IntegerRaster &susceptible, IntegerRaster &resistant)
+    bool manage(const Date& current, IntegerRaster& infected,
+                IntegerRaster& susceptible, IntegerRaster& resistant)
     {
         bool applied = false;
         for (unsigned i = 0; i < treatments.size(); i++) {
-            if (treatments[i].should_start(current)) {
-                treatments[i].apply_treatment(infected, susceptible, resistant);
+            if (treatments[i]->should_start(current)) {
+                treatments[i]->apply_treatment(infected, susceptible, resistant);
                 applied = true;
             }
-            else if (treatments[i].should_end(current)) {
-                treatments[i].end_treatment(susceptible, resistant);
+            else if (treatments[i]->should_end(current)) {
+                treatments[i]->end_treatment(susceptible, resistant);
                 applied = true;
             }
         }
         return applied;
     }
-
-    bool pesticide_management_mortality(IntegerRaster &infected)
+    bool manage_mortality(IntegerRaster& infected)
     {
         bool applied = false;
         for (unsigned i = 0; i < treatments.size(); i++)
-            if (treatments[i].should_apply_mortality()) {
-                treatments[i].apply_treatment_mortality(infected);
+            if (treatments[i]->should_apply_mortality()) {
+                treatments[i]->apply_treatment_mortality(infected);
                 applied = true;
             }
         return applied;
     }
+    /* this needs to be called when going back
+       when doing computational steering */
+    void reset(const Date& date)
+    {
+        for (auto item : treatments)
+        {
+            item->reset(date);
+            item->get_start();
+        }
+    }
+    void clear_after_date(const Date& date)
+    {
+        for(auto& treatment : treatments)
+        {
+            if (treatment->get_start() > date)
+            {
+                delete treatment;
+                treatment = nullptr;
+            }
+        }
+        treatments.erase(std::remove(treatments.begin(), treatments.end(), nullptr), treatments.end());
+    }
 };
 
-};
+}
 #endif // POPS_TREATMENTS_HPP
 

--- a/treatments.hpp
+++ b/treatments.hpp
@@ -157,7 +157,7 @@ public:
                        std::function<void (Date&)> increase_by_step):
         BaseTreatment<IntegerRaster, FloatRaster>(map, start, treatment_application, increase_by_step)
     {
-        this->end_.increased_by_days(num_days);
+        this->end_.add_days(num_days);
     }
     bool should_start(const Date& date) override
     {
@@ -211,8 +211,11 @@ public:
  * and using pesticide (temporarily removed).
  * Each treatment can have unique date, type (simple, pesticide),
  * length (in case of pesticide), and treatment application.
+ *
  * Pesticide treatments should not overlap spatially AND temporally
- * because of single resistance raster.
+ * because of single resistance raster. In that case all resistant
+ * populations that overlap both spatially and temporally
+ * are returned to the susceptible pool when the first treatment ends.
  */
 template<typename IntegerRaster, typename FloatRaster>
 class Treatments

--- a/treatments.hpp
+++ b/treatments.hpp
@@ -18,10 +18,13 @@
 #define POPS_TREATMENTS_HPP
 
 #include "raster.hpp"
+#include "date.hpp"
 
 #include <map>
+#include <vector>
 
 namespace pops {
+
 
 /**
  * @brief The enum to decide how threatment is applied
@@ -95,6 +98,145 @@ public:
     }
 };
 
-}
+template<typename IntegerRaster, typename FloatRaster>
+class PesticideTreatment
+{
+private:
+    Date start;
+    Date end;
+    bool resistant;
+    bool apply_mortality;
+    FloatRaster map;
+    TreatmentApplication application;
+public:
+    Treatment(const FloatRaster &map, const Date &start, int num_days,
+              TreatmentApplication treatment_application):
+        map(map), start(start), resistant(false), apply_mortality(false), application(treatment_application)
+    {
+        Date end_date = Date(start);
+        end_date.increased_by_days(num_days);
+    }
+    Treatment() = delete;
+
+    bool should_start(const Date &date)
+    {
+        if (!resistant && date >= start && date < end)
+            return true;
+        return false;
+    }
+    bool should_end(const Date &date)
+    {
+        if (resistant && date >= end)
+            return true;
+        return false;
+    }
+    bool should_apply_mortality()
+    {
+        return apply_mortality;
+    }
+
+    void reset_resistance(){
+        resistant = false;
+    }
+
+    void apply_treatment(IntegerRaster &infected, IntegerRaster &susceptible, IntegerRaster &resistant)
+    {
+        for(unsigned i = 0; i < infected.rows(); i++)
+            for(unsigned j = 0; j < infected.cols(); j++) {
+                int infected_resistant;
+                int susceptible_resistant = susceptible(i, j) * map(i, j);
+                if (application == TreatmentApplication::Ratio) {
+                    infected_resistant = infected(i, j) * map(i, j);
+                }
+                else if (application == TreatmentApplication::AllInfectedInCell) {
+                    infected_resistant = map(i, j) ? infected(i, j): 0;
+                }
+                infected(i, j) -= infected_resistant;
+                resistant(i, j) = infected_resistant + susceptible_resistant;
+                susceptible(i, j) -= susceptible_resistant;
+            }
+        resistant = true;
+        apply_mortality = true;
+    }
+    void end_treatment(IntegerRaster &susceptible, IntegerRaster &resistant)
+    {
+        for(unsigned i = 0; i < resistant.rows(); i++)
+            for(unsigned j = 0; j < resistant.cols(); j++) {
+                if (map(i, j) > 0){
+                    susceptible(i, j) += resistant(i, j);
+                    resistant(i, j) = 0;
+                }
+            }
+        resistant = false;
+    }
+    void apply_treatment_mortality(IntegerRaster &infected)
+    {
+        for(unsigned i = 0; i < infected.rows(); i++)
+            for(unsigned j = 0; j < infected.cols(); j++) {
+                if (application == TreatmentApplication::Ratio) {
+                    infected(i, j) = infected(i, j) * map(i, j);
+                }
+                else if (application == TreatmentApplication::AllInfectedInCell) {
+                    infected(i, j) = map(i, j) ? 0 : infected(i, j);
+                }
+            }
+        apply_mortality = false;
+    }
+};
+
+
+template<typename IntegerRaster, typename FloatRaster>
+class PesticideTreatments
+{
+private:
+    std::vector<PesticideTreatment<IntegerRaster, FloatRaster>> treatments;
+    TreatmentApplication application;
+
+public:
+    PesticideTreatments(TreatmentApplication treatment_application = TreatmentApplication::Ratio) :
+        application(treatment_application)
+    {}
+    void add_treatment(const FloatRaster &map, const Date &start_date, int num_days)
+    {
+        treatments.emplace_back(map, start_date, num_days, application);
+    }
+    /* this needs to be called when going back
+       when doing computational steering */
+    void reset_resistance()
+    {
+        for (unsigned i = 0; i < treatments.size(); i++)
+            treatments[i].reset_resistance();
+    }
+
+    bool pesticide_management(const Date &current, IntegerRaster &infected,
+                              IntegerRaster &susceptible, IntegerRaster &resistant)
+    {
+        bool applied = false;
+        for (unsigned i = 0; i < treatments.size(); i++) {
+            if (treatments[i].should_start(current)) {
+                treatments[i].apply_treatment(infected, susceptible, resistant);
+                applied = true;
+            }
+            else if (treatments[i].should_end(current)) {
+                treatments[i].end_treatment(susceptible, resistant);
+                applied = true;
+            }
+        }
+        return applied;
+    }
+
+    bool pesticide_management_mortality(IntegerRaster &infected)
+    {
+        bool applied = false;
+        for (unsigned i = 0; i < treatments.size(); i++)
+            if (treatments[i].should_apply_mortality()) {
+                treatments[i].apply_treatment_mortality(infected);
+                applied = true;
+            }
+        return applied;
+    }
+};
+
+};
 #endif // POPS_TREATMENTS_HPP
 

--- a/treatments.hpp
+++ b/treatments.hpp
@@ -37,6 +37,15 @@ enum class TreatmentApplication {
 
 /*!
  * Abstract interface for treatment classes
+ *
+ * The class is meant for better internal code
+ * layout and, at this point, it is not meant
+ * as a universal matured interface for treatments.
+ * Functions apply_treatment and end_treatment
+ * are examples where we account for the current
+ * concrete classes and will introduce more
+ * general set of parameters only when
+ * needed for additional classes.
  */
 template<typename IntegerRaster, typename FloatRaster>
 class AbstractTreatment
@@ -222,6 +231,9 @@ public:
      * \brief Add treatment, based on parameters it is distinguished
      * which treatment it will be.
      *
+     * This works internally like a factory function
+     * separating the user from all treatment classes.
+     *
      * \param map treatment raster
      * \param start_date date when treatment is applied
      * \param num_days for simple treatments should be 0, otherwise number of days host is resistant
@@ -251,18 +263,18 @@ public:
     bool manage(const Date& current, IntegerRaster& infected,
                 IntegerRaster& susceptible, IntegerRaster& resistant)
     {
-        bool applied = false;
+        bool changed = false;
         for (unsigned i = 0; i < treatments.size(); i++) {
             if (treatments[i]->should_start(current)) {
                 treatments[i]->apply_treatment(infected, susceptible, resistant);
-                applied = true;
+                changed = true;
             }
             else if (treatments[i]->should_end(current)) {
                 treatments[i]->end_treatment(susceptible, resistant);
-                applied = true;
+                changed = true;
             }
         }
-        return applied;
+        return changed;
     }
     /*!
      * \brief Separately manage mortality infected cohorts


### PR DESCRIPTION
Complete rewrite of treatment class. Introduces abstract class for treatments, inherited by SimpleTreatment (remove infected and susceptible) and PesticideTreatment (move infected and susceptible to resistant for number of days and then back to susceptible). Class Treatments keeps track of all treatments. Workflow looks like this:

    Treatments::add_treatment(raster, date, num_days, treatment_application, simulation_step)
    for each step in simulation:
         Treatments::manage(step, infected, susceptible, resistant)
         if (mortality)
               ....
              Treatments::manage_mortality(step, infected_mortality_tracker)

Assumptions:  
- Treatments can be mixed, but there can't be any spatially AND temporally overlapping treatments.