### PR TITLE
WIP: scheduling system for simulation (spread, treatments, export, mortality, lethal temp)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test_simulation
 test_treatments
 test_spread_rate
 test_statistics
+test_scheduling
 # generated documentation
 html
 # Qt Creator files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project should be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2019-12-18 - More date functionality
+
+### Added
+
+- functions to check if a date is the last day or week of a month
+
 ## 2019-10-29 - More raster generalizations
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXXFLAGS := $(CXXFLAGS) -std=c++11 -pedantic -Wall -Wextra
 COMMON_DEFINES := -D POPS_TEST
 
-all: test_date test_raster test_simulation test_treatments test_spread_rate test_statistics
+all: test_date test_raster test_simulation test_treatments test_spread_rate test_statistics test_scheduling
 
 test_date: test_date.cpp date.hpp
 	g++ $(CXXFLAGS) $(COMMON_DEFINES) test_date.cpp -o test_date
@@ -20,6 +20,9 @@ test_spread_rate: test_spread_rate.cpp *.hpp
 
 test_statistics: test_statistics.cpp *.hpp
 	g++ $(CXXFLAGS) $(COMMON_DEFINES) test_statistics.cpp -o test_statistics
+
+test_scheduling: test_scheduling.cpp *.hpp
+	g++ $(CXXFLAGS) $(COMMON_DEFINES) test_scheduling.cpp -o test_scheduling
 test:
 	./test_date
 	./test_raster
@@ -27,6 +30,7 @@ test:
 	./test_treatments
 	./test_spread_rate
 	./test_statistics
+	./test_scheduling
 
 doc:
 	doxygen
@@ -38,3 +42,4 @@ clean:
 	rm -f test_treatments
 	rm -f test_spread_rate
 	rm -f test_statistics
+	rm -f test_scheduling

--- a/date.hpp
+++ b/date.hpp
@@ -162,11 +162,11 @@ bool Date::is_last_day_of_year()
 bool Date::is_last_week_of_month()
 {
   if (this->is_leap_year()){
-    if ((day_ + 7) == day_in_month[1][month_])
+    if ((day_ + 7) >= day_in_month[1][month_])
       return true;
     return false;
   } else {
-    if ((day_ + 7)== day_in_month[0][month_])
+    if ((day_ + 7) >= day_in_month[0][month_])
       return true;
     return false;
   }

--- a/date.hpp
+++ b/date.hpp
@@ -1,7 +1,7 @@
 /*
  * SOD model - date manipulation
  *
- * Copyright (C) 2015-2017 by the authors.
+ * Copyright (C) 2015-2019 by the authors.
  *
  * Authors: Zexi Chen (zchen22 ncsu edu)
  *          Anna Petrasova
@@ -59,6 +59,8 @@ public:
     inline bool is_last_week_of_year();
     inline bool is_last_month_of_year();
     inline bool is_last_day_of_year();
+    inline bool is_last_day_of_month();
+    inline bool is_last_week_of_month();
     inline bool is_leap_year();
     int month() const { return month_; }
     int year() const { return year_; }
@@ -155,6 +157,32 @@ bool Date::is_last_day_of_year()
     if (month_ == 12 && day_ == 31)
         return true;
     return false;
+}
+
+bool Date::is_last_week_of_month()
+{
+  if (this->is_leap_year()){
+    if ((day_ + 7) == day_in_month[1][month_])
+      return true;
+    return false;
+  } else {
+    if ((day_ + 7)== day_in_month[0][month_])
+      return true;
+    return false;
+  }
+}
+
+bool Date::is_last_day_of_month()
+{
+  if (this->is_leap_year()){
+    if (day_ == day_in_month[1][month_])
+      return true;
+    return false;
+  } else {
+    if (day_ == day_in_month[0][month_])
+      return true;
+    return false;
+  }
 }
 
 Date Date::get_next_year_end()

--- a/date.hpp
+++ b/date.hpp
@@ -58,6 +58,7 @@ public:
     inline Date get_last_day_of_month();
     inline bool is_last_week_of_year();
     inline bool is_last_month_of_year();
+    inline bool is_last_day_of_year();
     inline bool is_leap_year();
     int month() const { return month_; }
     int year() const { return year_; }
@@ -145,6 +146,13 @@ bool Date::is_last_week_of_year()
 bool Date::is_last_month_of_year()
 {
     if (month_ == 12)
+        return true;
+    return false;
+}
+
+bool Date::is_last_day_of_year()
+{
+    if (month_ == 12 && day_ == 31)
         return true;
     return false;
 }
@@ -410,7 +418,7 @@ public:
      * \param month A month in year (1-12)
      * \return true if in season, false otherwise
      */
-    inline bool month_in_season(int month)
+    inline bool month_in_season(int month) const
     {
         return month >= start_month_ && month <= end_month_;
     }

--- a/scheduling.hpp
+++ b/scheduling.hpp
@@ -83,7 +83,8 @@ public:
             Date start(date);
             increase_date(date);
             Date end(date);
-            steps.push_back(Step(start, end.get_previous_day()));
+            end.subtract_day();
+            steps.push_back(Step(start, end));
             step++;
         }
         num_steps = step;

--- a/scheduling.hpp
+++ b/scheduling.hpp
@@ -1,0 +1,171 @@
+/*
+ * SOD model - scheduling simulation steps
+ *
+ * Copyright (C) 2015-2019 by the authors.
+ *
+ * Authors: Anna Petrasova
+ *          Vaclav Petras
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+
+#ifndef POPS_SCHEDULING_HPP
+#define POPS_SCHEDULING_HPP
+
+#include <iostream>
+#include <vector>
+
+#include "date.hpp"
+
+namespace pops {
+
+/*! Representation and manipulation of a date for the simulation.
+ *
+ */
+
+/*!
+ * 
+ */
+class Step
+{
+public:
+    Step(Date start_date, Date end_date)
+        : start_date_(start_date), end_date_(end_date)
+    {}
+    inline Date start_date(){return start_date_;}
+    inline Date end_date(){return end_date_;}
+    inline friend std::ostream& operator<<(std::ostream& os, const Step &step);
+private:
+    Date start_date_;
+    Date end_date_;
+};
+std::ostream& operator<<(std::ostream& os, const Step &step)
+{
+    os << step.start_date_ << " - " << step.end_date_;
+    return os;
+}
+
+/**
+ * @brief Enum for step unit
+ */
+enum class StepUnit {
+    Day, Month
+};
+
+class Scheduler
+{
+public:
+    Scheduler(const Date start, const Date end, StepUnit spread_unit, unsigned spread_num_units)
+        :
+          start_(start),
+          end_(end),
+          spread_unit_(spread_unit),
+          spread_num_units_(spread_num_units)
+    {
+        if (start >= end)
+            throw std::invalid_argument("Start date must be before end date");
+        Date d(start);
+        increase_date(d);
+        if (d > end)
+            throw std::invalid_argument("There must be at least one step between start and end date");
+        if (spread_unit == StepUnit::Month && start.day() != 1)
+            throw std::invalid_argument("If step unit is month, start date must start the first day of a month");
+        
+        Date date(start_);
+        unsigned step = 0;
+        while (date < end_) {
+            Date start(date);
+            increase_date(date);
+            Date end(date);
+            steps.push_back(Step(start, end.get_previous_day()));
+            step++;
+        }
+        num_steps = step;
+    }
+
+    unsigned get_num_steps() {
+        return num_steps;
+    }
+
+    std::vector<bool> schedule_spread(const Season &season) {
+        std::vector<bool> schedule;
+        schedule.reserve(num_steps);
+        for (Step step : steps) {
+            if (season.month_in_season(step.start_date().month()) || season.month_in_season(step.end_date().month()))
+                schedule.push_back(true);
+            else
+                schedule.push_back(false);
+        }
+        return schedule;
+    }
+    std::vector<bool> schedule_action_yearly() {
+        std::vector<bool> schedule;
+        schedule.reserve(num_steps);
+        for (Step step : steps) {
+            if (step.end_date().is_last_day_of_year())
+                schedule.push_back(true);
+            else
+                schedule.push_back(false);
+        }
+        return schedule;
+    }
+
+    std::vector<bool> schedule_action_nsteps(unsigned n_steps) {
+        std::vector<bool> schedule;
+        schedule.reserve(num_steps);
+        for (unsigned i = 0; i < num_steps; i++) {
+            if ((i + 1) % n_steps == 0)
+                schedule.push_back(true);
+            else
+                schedule.push_back(false);
+        }
+        return schedule;
+    }
+
+    unsigned schedule_action_date(const Date &date) {
+        for (unsigned i = 0; i < num_steps; i++) {
+            if (date >= steps[i].start_date() && date <= steps[i].end_date())
+                return i;
+        }
+        throw std::invalid_argument("Date is outside of schedule");
+    }
+    void debug_schedule(std::vector<bool> &schedule) {
+        for (unsigned i = 0; i < num_steps; i++)
+            std::cout << steps[i] << ": " << (schedule.at(i) ? "true" : "false") << std::endl;
+    }
+    void debug_schedule(unsigned n) {
+        for (unsigned i = 0; i < num_steps; i++)
+            std::cout << steps[i] << ": " << (n == i ? "true" : "false") << std::endl;
+    }
+
+private:
+    Date start_;
+    Date end_;
+    StepUnit spread_unit_;
+    unsigned spread_num_units_;
+    std::vector<Step> steps;
+    unsigned num_steps;
+
+    void increase_date(Date &date) {
+        if (spread_unit_ == StepUnit::Day) {
+            date.increased_by_days(spread_num_units_);
+        }
+        else if (spread_unit_ == StepUnit::Month) {
+            for (unsigned i = 0; i < spread_num_units_; i++) {
+                date.increased_by_month();
+            }
+        }
+    }
+};
+
+
+
+} // namespace pops
+
+#endif // POPS_SCHEDULING_HPP

--- a/scheduling.hpp
+++ b/scheduling.hpp
@@ -105,7 +105,25 @@ public:
         }
         return schedule;
     }
-    std::vector<bool> schedule_action_yearly() {
+    std::vector<bool> schedule_action_yearly(int month, int day) {
+        std::vector<bool> schedule;
+        schedule.reserve(num_steps);
+        for (Step step : steps) {
+            Date st = step.start_date();
+            Date end = step.end_date();
+            /* this doesn't handle cases where
+               there is change in year within interval,
+               but that doesn't happen with current implementation */
+            Date test(st.year(), month, day);
+            if ((test >= st && test <= end))
+                schedule.push_back(true);
+            else
+                schedule.push_back(false);
+        }
+        return schedule;
+    }
+
+    std::vector<bool> schedule_action_end_of_year() {
         std::vector<bool> schedule;
         schedule.reserve(num_steps);
         for (Step step : steps) {

--- a/scheduling.hpp
+++ b/scheduling.hpp
@@ -147,6 +147,20 @@ public:
         return schedule;
     }
 
+    std::vector<bool> schedule_action_monthly() {
+        std::vector<bool> schedule;
+        schedule.reserve(num_steps);
+        for (Step step : steps) {
+            Date st = step.start_date();
+            Date end = step.end_date();
+            if (st.month() != end.month() || end.is_last_day_of_month())
+                schedule.push_back(true);
+            else
+                schedule.push_back(false);
+        }
+        return schedule;
+    }
+
     unsigned schedule_action_date(const Date &date) {
         for (unsigned i = 0; i < num_steps; i++) {
             if (date >= steps[i].start_date() && date <= steps[i].end_date())

--- a/test_scheduling.cpp
+++ b/test_scheduling.cpp
@@ -246,6 +246,43 @@ int test_schedule_action_date()
     return num_errors;
 }
 
+int test_simulation_step_to_action_step()
+{
+    int num_errors = 0;
+
+    Date st(2020, 1, 1);
+    Date end(2021, 12, 31);
+
+    Scheduler scheduling1(st, end, StepUnit::Month, 1);
+    std::vector<bool> vect_action1 = scheduling1.schedule_action_yearly(4, 5);
+    unsigned i1 = simulation_step_to_action_step(vect_action1, 3);
+    unsigned i2 = simulation_step_to_action_step(vect_action1, 15);
+    if (!(i1 == 0 && i2 == 1)) {
+        std::cout << "Failed simulation_step_to_action_step" << std::endl;
+        num_errors++;
+    }
+
+    return num_errors;
+}
+
+int test_get_number_of_scheduled_actions()
+{
+    int num_errors = 0;
+
+    Date st(2020, 1, 1);
+    Date end(2021, 12, 31);
+
+    Scheduler scheduling1(st, end, StepUnit::Month, 1);
+    std::vector<bool> vect_action1 = scheduling1.schedule_action_yearly(4, 5);
+    unsigned n = get_number_of_scheduled_actions(vect_action1);
+    if (n != 2) {
+        std::cout << "Failed get_number_of_scheduled_actions" << std::endl;
+        num_errors++;
+    }
+
+    return num_errors;
+}
+
 int main()
 {
     int num_errors = 0;
@@ -258,6 +295,8 @@ int main()
     num_errors += test_schedule_action_nsteps();
     num_errors += test_schedule_action_date();
     num_errors += test_schedule_action_monthly();
+    num_errors += test_simulation_step_to_action_step();
+    num_errors += test_get_number_of_scheduled_actions();
 
     return num_errors;
 }

--- a/test_scheduling.cpp
+++ b/test_scheduling.cpp
@@ -1,0 +1,227 @@
+#ifdef POPS_TEST
+
+/*
+ * Simple compilation test for the PoPS Scheduling class.
+ *
+ * Copyright (C) 2018-2019 by the authors.
+ *
+ * Authors: Anna Petrasova <akratoc gmail com>
+ *
+ * This file is part of PoPS.
+
+ * PoPS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+
+ * PoPS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with PoPS. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <vector>
+
+#include "scheduling.hpp"
+#include "date.hpp"
+
+
+using namespace pops;
+
+int test_schedule_spread_month()
+{
+    int num_errors = 0;
+
+    Date st(2020, 1, 1);
+    Date end(2021, 12, 31);
+    
+    Scheduler scheduling1(st, end, StepUnit::Month, 1);
+    std::vector<bool> vect1 = scheduling1.schedule_spread(Season(1, 12));
+    if (scheduling1.get_num_steps() != 24) {
+        std::cout << "Failed scheduling of monthly spread" << std::endl;
+        scheduling1.debug_schedule(vect1);
+        num_errors++;
+    }
+
+    Scheduler scheduling2(st, end, StepUnit::Month, 3);
+    std::vector<bool> vect2 = scheduling2.schedule_spread(Season(1, 12));
+    if (scheduling2.get_num_steps() != 8) {
+        std::cout << "Failed scheduling of monthly spread" << std::endl;
+        scheduling2.debug_schedule(vect2);
+        num_errors++;
+    }
+
+    Scheduler scheduling3(st, end, StepUnit::Month, 5);
+    std::vector<bool> vect3 = scheduling3.schedule_spread( Season(1, 12));
+    if (scheduling3.get_num_steps() != 5) {
+        std::cout << "Failed scheduling of monthly spread" << std::endl;
+        scheduling3.debug_schedule(vect3);
+        num_errors++;
+    }
+
+    Date st2(2020, 2, 1);
+    Date end2(2021, 12, 18);
+
+    Scheduler scheduling4(st2, end2, StepUnit::Month, 2);
+    std::vector<bool> vect4 = scheduling4.schedule_spread(Season(1, 12));
+    if (scheduling4.get_num_steps() != 12) {
+        std::cout << "Failed scheduling of monthly spread" << std::endl;
+        scheduling4.debug_schedule(vect4);
+        num_errors++;
+    }
+
+    Scheduler scheduling5(st2, end2, StepUnit::Month, 2);
+    std::vector<bool> vect5 = scheduling5.schedule_spread(Season(3, 9));
+    if (scheduling5.get_num_steps() != 12) {
+        std::cout << "Failed scheduling of monthly spread" << std::endl;
+        scheduling5.debug_schedule(vect5);
+        num_errors++;
+    }
+    
+    return num_errors;
+}
+
+int test_schedule_spread_days()
+{
+    int num_errors = 0;
+
+    Date st(2020, 4, 7);
+    Date end(2020, 11, 15);
+
+    Scheduler scheduling1(st, end, StepUnit::Day, 21);
+    std::vector<bool> vect1 = scheduling1.schedule_spread(Season(1, 12));
+    if (scheduling1.get_num_steps() != 11) {
+        std::cout << "Failed scheduling of 21-day spread" << std::endl;
+        scheduling1.debug_schedule(vect1);
+        num_errors++;
+    }
+
+    Date st1(2020, 12, 2);
+    Date end1(2021, 4, 15);
+
+    Scheduler scheduling2(st1, end1, StepUnit::Day, 21);
+    std::vector<bool> vect2 = scheduling2.schedule_spread(Season(1, 12));
+    if (scheduling2.get_num_steps() != 6) {
+        std::cout << "Failed scheduling of 21-day spread" << std::endl;
+        scheduling2.debug_schedule(vect2);
+        num_errors++;
+    }
+
+    Date st2(2020, 12, 14);
+
+    Scheduler scheduling3(st2, end1, StepUnit::Day, 21);
+    std::vector<bool> vect3 = scheduling3.schedule_spread(Season(1, 12));
+    if (scheduling3.get_num_steps() != 6) {
+        std::cout << "Failed scheduling of 21-day spread" << std::endl;
+        scheduling3.debug_schedule(vect3);
+        num_errors++;
+    }
+
+    Date st3(2020, 12, 24);
+
+    Scheduler scheduling4(st3, end1, StepUnit::Day, 21);
+    std::vector<bool> vect4 = scheduling4.schedule_spread(Season(1, 12));
+    if (scheduling3.get_num_steps() != 6) {
+        std::cout << "Failed scheduling of 21-day spread" << std::endl;
+        scheduling4.debug_schedule(vect4);
+        num_errors++;
+    }
+    return num_errors;
+}
+
+
+int test_schedule_action_yearly()
+{
+    int num_errors = 0;
+
+    Date st(2020, 1, 1);
+    Date end(2021, 12, 31);
+
+    Scheduler scheduling1(st, end, StepUnit::Month, 2);
+    std::vector<bool> vect1 = scheduling1.schedule_spread(Season(1, 12));
+    std::vector<bool> vect_action1 =  scheduling1.schedule_action_yearly();
+    if (scheduling1.get_num_steps() != 12) {
+        std::cout << "Failed scheduling of yearly action" << std::endl;
+        scheduling1.debug_schedule(vect_action1);
+        num_errors++;
+    }
+
+    Date st1(2020, 1, 1);
+    Date end1(2022, 11, 15);
+
+    Scheduler scheduling2(st1, end1, StepUnit::Month, 2);
+    std::vector<bool> vect2 = scheduling2.schedule_spread(Season(2, 8));
+    std::vector<bool> vect_action2 =  scheduling2.schedule_action_yearly();
+    if (scheduling2.get_num_steps() != 18) {
+        std::cout << "Failed scheduling of yearly action" << std::endl;
+        scheduling2.debug_schedule(vect_action2);
+        num_errors++;
+    }
+
+    return num_errors;
+}
+
+int test_schedule_action_nsteps()
+{
+    int num_errors = 0;
+
+    Date st(2020, 1, 1);
+    Date end(2021, 12, 31);
+
+    Scheduler scheduling1(st, end, StepUnit::Month, 2);
+    std::vector<bool> vect1 = scheduling1.schedule_spread(Season(1, 12));
+    std::vector<bool> vect_action1 =  scheduling1.schedule_action_nsteps(2);
+    if (scheduling1.get_num_steps() != 12) {
+        std::cout << "Failed scheduling of n-steps action" << std::endl;
+        scheduling1.debug_schedule(vect_action1);
+        num_errors++;
+    }
+
+    Scheduler scheduling2(st, end, StepUnit::Day, 15);
+    std::vector<bool> vect2 = scheduling2.schedule_spread(Season(2, 10));
+    std::vector<bool> vect_action2 =  scheduling2.schedule_action_nsteps(2);
+    if (scheduling2.get_num_steps() != 48) {
+        std::cout << "Failed scheduling of n-steps action" << std::endl;
+        scheduling2.debug_schedule(vect_action2);
+        num_errors++;
+    }
+
+    return num_errors;
+}
+
+int test_schedule_action_date()
+{
+    int num_errors = 0;
+
+    Date st(2020, 1, 1);
+    Date end(2021, 12, 31);
+
+    Scheduler scheduling1(st, end, StepUnit::Month, 2);
+    unsigned n = scheduling1.schedule_action_date(Date(2020, 3, 3));
+    if (n != 12) {
+        std::cout << "Failed scheduling of date action" << std::endl;
+        scheduling1.debug_schedule(n);
+        num_errors++;
+    }
+
+    return num_errors;
+}
+
+int main()
+{
+    int num_errors = 0;
+
+
+    num_errors += test_schedule_spread_month();
+    num_errors += test_schedule_spread_days();
+    num_errors += test_schedule_action_yearly();
+    num_errors += test_schedule_action_nsteps();
+    num_errors += test_schedule_action_date();
+
+    return num_errors;
+}
+
+#endif  // POPS_TEST

--- a/test_scheduling.cpp
+++ b/test_scheduling.cpp
@@ -201,7 +201,7 @@ int test_schedule_action_date()
 
     Scheduler scheduling1(st, end, StepUnit::Month, 2);
     unsigned n = scheduling1.schedule_action_date(Date(2020, 3, 3));
-    if (n != 12) {
+    if (n != 1) {
         std::cout << "Failed scheduling of date action" << std::endl;
         scheduling1.debug_schedule(n);
         num_errors++;

--- a/test_scheduling.cpp
+++ b/test_scheduling.cpp
@@ -141,10 +141,29 @@ int test_schedule_action_yearly()
     Date end(2021, 12, 31);
 
     Scheduler scheduling1(st, end, StepUnit::Month, 2);
-    std::vector<bool> vect1 = scheduling1.schedule_spread(Season(1, 12));
-    std::vector<bool> vect_action1 =  scheduling1.schedule_action_yearly();
-    if (scheduling1.get_num_steps() != 12) {
+    std::vector<bool> vect_action1 = scheduling1.schedule_action_yearly(4, 5);
+    if (!(vect_action1[1] && vect_action1[7])) {
+        scheduling1.debug_schedule(vect_action1);
         std::cout << "Failed scheduling of yearly action" << std::endl;
+        num_errors++;
+    }
+
+    return num_errors;
+}
+
+
+int test_schedule_action_end_of_year()
+{
+    int num_errors = 0;
+
+    Date st(2020, 1, 1);
+    Date end(2021, 12, 31);
+
+    Scheduler scheduling1(st, end, StepUnit::Month, 2);
+    std::vector<bool> vect1 = scheduling1.schedule_spread(Season(1, 12));
+    std::vector<bool> vect_action1 =  scheduling1.schedule_action_end_of_year();
+    if (scheduling1.get_num_steps() != 12) {
+        std::cout << "Failed scheduling of end of year action" << std::endl;
         scheduling1.debug_schedule(vect_action1);
         num_errors++;
     }
@@ -154,9 +173,9 @@ int test_schedule_action_yearly()
 
     Scheduler scheduling2(st1, end1, StepUnit::Month, 2);
     std::vector<bool> vect2 = scheduling2.schedule_spread(Season(2, 8));
-    std::vector<bool> vect_action2 =  scheduling2.schedule_action_yearly();
+    std::vector<bool> vect_action2 =  scheduling2.schedule_action_end_of_year();
     if (scheduling2.get_num_steps() != 18) {
-        std::cout << "Failed scheduling of yearly action" << std::endl;
+        std::cout << "Failed scheduling of end of year action" << std::endl;
         scheduling2.debug_schedule(vect_action2);
         num_errors++;
     }
@@ -218,6 +237,7 @@ int main()
     num_errors += test_schedule_spread_month();
     num_errors += test_schedule_spread_days();
     num_errors += test_schedule_action_yearly();
+    num_errors += test_schedule_action_end_of_year();
     num_errors += test_schedule_action_nsteps();
     num_errors += test_schedule_action_date();
 

--- a/test_scheduling.cpp
+++ b/test_scheduling.cpp
@@ -211,6 +211,23 @@ int test_schedule_action_nsteps()
     return num_errors;
 }
 
+int test_schedule_action_monthly()
+{
+    int num_errors = 0;
+
+    Date st(2020, 1, 1);
+    Date end(2021, 12, 31);
+
+    Scheduler scheduling1(st, end, StepUnit::Day, 7);
+    std::vector<bool> schedule = scheduling1.schedule_action_monthly();
+    if (!(schedule[4] && schedule[8])) {
+        std::cout << "Failed scheduling of monthly action" << std::endl;
+        scheduling1.debug_schedule(schedule);
+        num_errors++;
+    }
+
+    return num_errors;
+}
 int test_schedule_action_date()
 {
     int num_errors = 0;
@@ -240,6 +257,7 @@ int main()
     num_errors += test_schedule_action_end_of_year();
     num_errors += test_schedule_action_nsteps();
     num_errors += test_schedule_action_date();
+    num_errors += test_schedule_action_monthly();
 
     return num_errors;
 }

--- a/test_treatments.cpp
+++ b/test_treatments.cpp
@@ -27,6 +27,7 @@
 #include "raster.hpp"
 #include "treatments.hpp"
 #include "date.hpp"
+#include "scheduling.hpp"
 
 
 using namespace pops;
@@ -35,14 +36,15 @@ using namespace pops;
 int test_application_ratio()
 {
     int num_errors = 0;
-    Treatments<Raster<int>, Raster<double>> treatments;
+    Scheduler scheduler(Date(2020, 1, 1), Date(2020, 12, 31), StepUnit::Month, 1);
+    Treatments<Raster<int>, Raster<double>> treatments(scheduler);
     Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
-    treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::Ratio, increase_by_step);
-    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+
+    treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::Ratio);
+    treatments.manage(0, infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 3}, {5, 42}};
     Raster<int> inf_treated = {{0, 2}, {4, 40}};
@@ -57,14 +59,14 @@ int test_application_ratio()
 int test_application_all_inf()
 {
     int num_errors = 0;
-    Treatments<Raster<int>, Raster<double>> treatments;
+    Scheduler scheduler(Date(2020, 1, 1), Date(2020, 12, 31), StepUnit::Month, 1);
+    Treatments<Raster<int>, Raster<double>> treatments(scheduler);
     Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
-    treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::AllInfectedInCell, increase_by_step);
-    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+    treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::AllInfectedInCell);
+    treatments.manage(0, infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 3}, {5, 42}};
     Raster<int> inf_treated = {{0, 0}, {0, 40}};
@@ -79,14 +81,15 @@ int test_application_all_inf()
 int test_application_ratio_pesticide()
 {
     int num_errors = 0;
-    Treatments<Raster<int>, Raster<double>> treatments;
+    Scheduler scheduler(Date(2020, 1, 1), Date(2020, 12, 31), StepUnit::Day, 7);
+    unsigned n = scheduler.schedule_action_date(Date(2020, 1, 1));
+    Treatments<Raster<int>, Raster<double>> treatments(scheduler);
     Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::Ratio, increase_by_step);
-    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::Ratio);
+    treatments.manage(n, infected, susceptible, resistant);
 
     Raster<int> treated = {{10, 6}, {20, 42}};
     Raster<int> inf_treated = {{1, 4}, {16, 40}};
@@ -96,7 +99,8 @@ int test_application_ratio_pesticide()
         std::cout << susceptible << infected << resistant;
         num_errors++;
     }
-    treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 3));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{0, 3}, {5, 42}};
     inf_treated = {{0, 2}, {4, 40}};
@@ -106,7 +110,8 @@ int test_application_ratio_pesticide()
         std::cout << susceptible << infected << resistant;
         num_errors++;
     }
-    treatments.manage(Date(2020, 5, 8), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 8));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{11, 8}, {32, 42}};
     resist = {{0, 0}, {0, 0}};
@@ -122,14 +127,15 @@ int test_application_ratio_pesticide()
 int test_application_all_inf_pesticide()
 {
     int num_errors = 0;
-    Treatments<Raster<int>, Raster<double>> treatments;
+    Scheduler scheduler(Date(2020, 1, 1), Date(2020, 12, 31), StepUnit::Day, 7);
+    Treatments<Raster<int>, Raster<double>> treatments(scheduler);
     Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::AllInfectedInCell, increase_by_step);
-    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::AllInfectedInCell);
+    unsigned n = scheduler.schedule_action_date(Date(2020, 1, 1));
+    treatments.manage(n, infected, susceptible, resistant);
 
     Raster<int> treated = {{10, 6}, {20, 42}};
     Raster<int> inf_treated = {{1, 4}, {16, 40}};
@@ -139,7 +145,8 @@ int test_application_all_inf_pesticide()
         std::cout << susceptible << infected << resistant;
         num_errors++;
     }
-    treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 3));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{0, 3}, {5, 42}};
     inf_treated = {{0, 0}, {0, 40}};
@@ -149,7 +156,8 @@ int test_application_all_inf_pesticide()
         std::cout << susceptible << infected << resistant;
         num_errors++;
     }
-    treatments.manage(Date(2020, 5, 8), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 8));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{11, 10}, {36, 42}};
     resist = {{0, 0}, {0, 0}};
@@ -165,17 +173,18 @@ int test_application_all_inf_pesticide()
 int test_combination()
 {
     int num_errors = 0;
-    Treatments<Raster<int>, Raster<double>> treatments;
+    Scheduler scheduler(Date(2020, 1, 1), Date(2020, 12, 31), StepUnit::Day, 7);
+    Treatments<Raster<int>, Raster<double>> treatments(scheduler);
     Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
     Raster<double> tr2 = {{1, 1}, {1, 1}};
 
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio, increase_by_step);
-    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio, increase_by_step);
-    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
+    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
+    unsigned n = scheduler.schedule_action_date(Date(2020, 1, 1));
+    treatments.manage(n, infected, susceptible, resistant);
 
     Raster<int> treated = {{10, 6}, {20, 42}};
     Raster<int> inf_treated = {{1, 4}, {16, 40}};
@@ -185,7 +194,8 @@ int test_combination()
         std::cout << susceptible << infected << resistant;
         num_errors++;
     }
-    treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 3));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{0, 3}, {5, 42}};
     inf_treated = {{0, 2}, {4, 40}};
@@ -195,7 +205,8 @@ int test_combination()
         std::cout << susceptible << infected << resistant;
         num_errors++;
     }
-    treatments.manage(Date(2020, 6, 3), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 2));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{0, 0}, {0, 0}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -205,7 +216,8 @@ int test_combination()
         std::cout << susceptible << infected << resistant;
         num_errors++;
     }
-    treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 8));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{0, 5}, {9, 82}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -223,18 +235,19 @@ int test_combination()
 int test_pesticide_temporal_overlap()
 {
     int num_errors = 0;
-    Treatments<Raster<int>, Raster<double>> treatments;
+    Scheduler scheduler(Date(2020, 1, 1), Date(2020, 12, 31), StepUnit::Day, 7);
+    Treatments<Raster<int>, Raster<double>> treatments(scheduler);
     Raster<double> tr1 = {{1, 1}, {0, 0}};
     Raster<double> tr2 = {{0, 0}, {1, 1}};
 
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 30, TreatmentApplication::Ratio, increase_by_step);
-    treatments.add_treatment(tr2, Date(2020, 5, 20), 30, TreatmentApplication::Ratio, increase_by_step);
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 30, TreatmentApplication::Ratio);
+    treatments.add_treatment(tr2, Date(2020, 5, 20), 30, TreatmentApplication::Ratio);
 
-    treatments.manage(Date(2020, 5, 1), infected, susceptible, resistant);
+    unsigned n = scheduler.schedule_action_date(Date(2020, 5, 1));
+    treatments.manage(n, infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 0}, {20, 42}};
     Raster<int> inf_treated = {{0, 0}, {16, 40}};
@@ -245,7 +258,8 @@ int test_pesticide_temporal_overlap()
         num_errors++;
     }
 
-    treatments.manage(Date(2020, 5, 20), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 20));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{0, 0}, {0, 0}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -256,7 +270,8 @@ int test_pesticide_temporal_overlap()
         num_errors++;
     }
 
-    treatments.manage(Date(2020, 6, 1), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 1));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{11, 10}, {0, 0}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -267,7 +282,8 @@ int test_pesticide_temporal_overlap()
         num_errors++;
     }
 
-    treatments.manage(Date(2020, 6, 21), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 21));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{11, 10}, {36, 82}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -284,22 +300,28 @@ int test_pesticide_temporal_overlap()
 int test_steering()
 {
     int num_errors = 0;
-    Treatments<Raster<int>, Raster<double>> treatments;
+    Scheduler scheduler(Date(2020, 1, 1), Date(2020, 12, 31), StepUnit::Day, 7);
+    Treatments<Raster<int>, Raster<double>> treatments(scheduler);
     Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
     Raster<double> tr2 = {{1, 1}, {1, 1}};
 
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio, increase_by_step);
-    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio, increase_by_step);
-    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 5, 12), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 6, 1), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 6, 15), infected, susceptible, resistant);
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
+    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
+    unsigned n = scheduler.schedule_action_date(Date(2020, 1, 1));
+    treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 3));
+    treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 12));
+    treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 1));
+    treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 8));
+    treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 15));
+    treatments.manage(n, infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 5}, {9, 82}};
     Raster<int> inf_treated = {{0, 0}, {0, 0}};
@@ -313,12 +335,18 @@ int test_steering()
     susceptible = {{10, 6}, {20, 42}};
     resistant = {{0, 0}, {0, 0}};
     infected = {{1, 4}, {16, 40}};
-    treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 5, 12), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 6, 1), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
-    treatments.manage(Date(2020, 6, 15), infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 1, 1));
+    treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 3));
+    treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 12));
+    treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 1));
+    treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 8));
+    treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 15));
+    treatments.manage(n, infected, susceptible, resistant);
 
     treated = {{0, 5}, {9, 82}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -336,7 +364,8 @@ int test_clear()
 {
     int num_errors = 0;
     int num_actions = 0;
-    Treatments<Raster<int>, Raster<double>> treatments;
+    Scheduler scheduler(Date(2020, 1, 1), Date(2020, 12, 31), StepUnit::Day, 7);
+    Treatments<Raster<int>, Raster<double>> treatments(scheduler);
     Raster<double> tr1 = {{1, 0.5}, {0.75, 0}};
     Raster<double> tr2 = {{1, 1}, {1, 1}};
     Raster<double> tr3 = {{1, 0}, {1, 0}};
@@ -344,17 +373,23 @@ int test_clear()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
-    std::function<void (Date&)> increase_by_step = &Date::increased_by_week;
-    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio, increase_by_step);
-    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio, increase_by_step);
-    treatments.add_treatment(tr3, Date(2020, 6, 8), 7, TreatmentApplication::Ratio, increase_by_step);
-    treatments.clear_after_date(Date(2020, 6, 1));
-    num_actions += treatments.manage(Date(2020, 1, 1), infected, susceptible, resistant);
-    num_actions += treatments.manage(Date(2020, 5, 3), infected, susceptible, resistant);
-    num_actions += treatments.manage(Date(2020, 5, 12), infected, susceptible, resistant);
-    num_actions += treatments.manage(Date(2020, 6, 1), infected, susceptible, resistant);
-    num_actions += treatments.manage(Date(2020, 6, 8), infected, susceptible, resistant);
-    num_actions += treatments.manage(Date(2020, 6, 15), infected, susceptible, resistant);
+    treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
+    treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
+    treatments.add_treatment(tr3, Date(2020, 6, 8), 7, TreatmentApplication::Ratio);
+    unsigned n = scheduler.schedule_action_date(Date(2020, 6, 1));
+    treatments.clear_after_step(n);
+    n = scheduler.schedule_action_date(Date(2020, 1, 1));
+    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 3));
+    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 5, 12));
+    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 1));
+    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 8));
+    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    n = scheduler.schedule_action_date(Date(2020, 6, 15));
+    num_actions += treatments.manage(n, infected, susceptible, resistant);
 
     Raster<int> treated = {{0, 5}, {9, 82}};
     Raster<int> inf_treated = {{0, 0}, {0, 0}};

--- a/treatments.hpp
+++ b/treatments.hpp
@@ -19,6 +19,7 @@
 
 #include "raster.hpp"
 #include "date.hpp"
+#include "scheduling.hpp"
 
 #include <map>
 #include <vector>
@@ -51,10 +52,10 @@ template<typename IntegerRaster, typename FloatRaster>
 class AbstractTreatment
 {
 public:
-    virtual Date get_start() = 0;
-    virtual Date get_end() = 0;
-    virtual bool should_start(const Date& date) = 0;
-    virtual bool should_end(const Date& date) = 0;
+    virtual unsigned get_start() = 0;
+    virtual unsigned get_end() = 0;
+    virtual bool should_start(unsigned step) = 0;
+    virtual bool should_end(unsigned step) = 0;
     virtual void apply_treatment(IntegerRaster& infected, IntegerRaster& susceptible, IntegerRaster& resistant) = 0;
     virtual void end_treatment(IntegerRaster& susceptible, IntegerRaster& resistant) = 0;
     virtual void apply_treatment_mortality(IntegerRaster& infected) = 0;
@@ -69,20 +70,18 @@ template<typename IntegerRaster, typename FloatRaster>
 class BaseTreatment : public AbstractTreatment<IntegerRaster, FloatRaster>
 {
 protected:
-    Date start_;
-    Date end_;
+    unsigned start_step_;
+    unsigned end_step_;
     FloatRaster map_;
     TreatmentApplication application_;
-    std::function<void (Date&)> increase_by_step_;
 public:
-    BaseTreatment(const FloatRaster& map, const Date& start,
-                  TreatmentApplication treatment_application,
-                  std::function<void (Date&)> increase_by_step):
-        start_(start), end_(start), map_(map),
-        application_(treatment_application), increase_by_step_(increase_by_step)
+    BaseTreatment(const FloatRaster& map, unsigned start,
+                  TreatmentApplication treatment_application):
+        start_step_(start), end_step_(start), map_(map),
+        application_(treatment_application)
     {}
-    Date get_start() {return start_;}
-    Date get_end() {return end_;}
+    unsigned get_start() {return start_step_;}
+    unsigned get_end() {return end_step_;}
     void apply_treatment_mortality(IntegerRaster& infected) override
     {
         for(unsigned i = 0; i < infected.rows(); i++)
@@ -106,20 +105,17 @@ template<typename IntegerRaster, typename FloatRaster>
 class SimpleTreatment : public BaseTreatment<IntegerRaster, FloatRaster>
 {
 public:
-    SimpleTreatment(const FloatRaster& map, const Date& start,
-                    TreatmentApplication treatment_application,
-                    std::function<void (Date&)> increase_by_step):
-        BaseTreatment<IntegerRaster, FloatRaster>(map, start, treatment_application, increase_by_step)
+    SimpleTreatment(const FloatRaster& map, unsigned     start,
+                    TreatmentApplication treatment_application):
+        BaseTreatment<IntegerRaster, FloatRaster>(map, start, treatment_application)
     {}
-    bool should_start(const Date& date) override
+    bool should_start(unsigned step) override
     {
-        Date st = Date(this->start_);
-        this->increase_by_step_(st);
-        if (date >= this->start_ && date < st)
+        if (this->start_step_ == step)
             return true;
         return false;
     }
-    bool should_end(const Date&) override
+    bool should_end(unsigned) override
     {
         return false;
     }
@@ -152,26 +148,21 @@ template<typename IntegerRaster, typename FloatRaster>
 class PesticideTreatment : public BaseTreatment<IntegerRaster, FloatRaster>
 {
 public:
-    PesticideTreatment(const FloatRaster& map, const Date& start, int num_days,
-                       TreatmentApplication treatment_application,
-                       std::function<void (Date&)> increase_by_step):
-        BaseTreatment<IntegerRaster, FloatRaster>(map, start, treatment_application, increase_by_step)
+    PesticideTreatment(const FloatRaster& map, unsigned start, unsigned end,
+                       TreatmentApplication treatment_application):
+        BaseTreatment<IntegerRaster, FloatRaster>(map, start, treatment_application)
     {
-        this->end_.add_days(num_days);
+        this->end_step_ = end;
     }
-    bool should_start(const Date& date) override
+    bool should_start(unsigned step) override
     {
-        Date st = Date(this->start_);
-        this->increase_by_step_(st);
-        if (date >= this->start_ && date < st)
+        if (this->start_step_ == step)
             return true;
         return false;
     }
-    bool should_end(const Date& date) override
+    bool should_end(unsigned step) override
     {
-        Date end = Date(this->end_);
-        this->increase_by_step_(end);
-        if (date >= this->end_ && date < end)
+        if (this->end_step_ == step)
             return true;
         return false;
     }
@@ -223,7 +214,9 @@ class Treatments
 {
 private:
     std::vector<AbstractTreatment<IntegerRaster, FloatRaster>*> treatments;
+    Scheduler scheduler_;
 public:
+    Treatments(const Scheduler &scheduler): scheduler_(scheduler) {}
     ~Treatments()
     {
         for (auto item : treatments)
@@ -244,13 +237,17 @@ public:
      * \param treatment_application if efficiency < 100% how should it be applied to infected/susceptible
      * \param increase_by_step function to increase simulation step
      */
-    void add_treatment(const FloatRaster& map, const Date& start_date, int num_days, TreatmentApplication treatment_application,
-                       std::function<void (Date&)> increase_by_step)
+    void add_treatment(const FloatRaster& map, const Date& start_date, int num_days, TreatmentApplication treatment_application)
     {
+        unsigned start = scheduler_.schedule_action_date(start_date);
         if (num_days == 0)
-            treatments.push_back(new SimpleTreatment<IntegerRaster, FloatRaster>(map, start_date, treatment_application, increase_by_step));
-        else
-            treatments.push_back(new PesticideTreatment<IntegerRaster, FloatRaster>(map, start_date, num_days, treatment_application, increase_by_step));
+            treatments.push_back(new SimpleTreatment<IntegerRaster, FloatRaster>(map, start, treatment_application));
+        else {
+            Date end_date(start_date);
+            end_date.add_days(num_days);
+            unsigned end = scheduler_.schedule_action_date(end_date);
+            treatments.push_back(new PesticideTreatment<IntegerRaster, FloatRaster>(map, start, end, treatment_application));
+        }
     }
     /*!
      * \brief Do management if needed.
@@ -258,13 +255,13 @@ public:
      * Decides internally whether any treatment needs to be
      * activated/deactivated.
      *
-     * \param current simulation date
+     * \param current simulation step
      * \param infected raster of infected host
      * \param susceptible raster of susceptible host
      * \param resistant raster of resistant host
      * \return true if any management action was necessary
      */
-    bool manage(const Date& current, IntegerRaster& infected,
+    bool manage(unsigned current, IntegerRaster& infected,
                 IntegerRaster& susceptible, IntegerRaster& resistant)
     {
         bool changed = false;
@@ -282,11 +279,11 @@ public:
     }
     /*!
      * \brief Separately manage mortality infected cohorts
-     * \param current simulation date
+     * \param current simulation step
      * \param infected raster of infected host
      * \return true if any management action was necessary
      */
-    bool manage_mortality(const Date& current, IntegerRaster& infected)
+    bool manage_mortality(unsigned current, IntegerRaster& infected)
     {
         bool applied = false;
         for (unsigned i = 0; i < treatments.size(); i++)
@@ -297,15 +294,15 @@ public:
         return applied;
     }
     /*!
-     * \brief Used to remove treatments after certain date.
+     * \brief Used to remove treatments after certain step.
      * Needed for computational steering.
-     * \param date simulation date
+     * \param step simulation step
      */
-    void clear_after_date(const Date& date)
+    void clear_after_step(unsigned step)
     {
         for(auto& treatment : treatments)
         {
-            if (treatment->get_start() > date)
+            if (treatment->get_start() > step)
             {
                 delete treatment;
                 treatment = nullptr;


### PR DESCRIPTION
This is a work-in-progress system to simplify and standardize scheduling events in simulation. A simple example is in tests:

    Date st(2020, 1, 1);
    Date end(2021, 12, 31);

    // define simulation time step, in this case every 2 months
    Scheduler scheduling(st, end, StepUnit::Month, 2);
    // get vector of bools if spread should happen in step N
    std::vector<bool> spread_schedule = scheduling.schedule_spread(Season(1, 12));

    // scheduling regular events:
    // do certain action (e.g. export) at the end of the year
    std::vector<bool> export_schedule =  scheduling.schedule_action_yearly();
    // do certain action (e.g. export) every N time steps (in this case 2* 2 months)
    std::vector<bool> export_schedule =  scheduling.schedule_action_nsteps(2);

    // scheduling irregular events (treatments)
    unsigned n = scheduling.schedule_action_date(Date(2020, 3, 3));

    // in the simulation loop
    for (unsigned i = 0; i < scheduling.get_num_steps(), ++i) {
        if (spread_schedule[i])
            // simulate spread
        if (export_schedule[i])
            // export results
        ...
    }


    // example of schedule with seasonality
    Date st(2020, 2, 1);
    Date end(2021, 12, 18);
    Scheduler scheduling (st, end, StepUnit::Month, 3);
    std::vector<bool> vect = scheduling.schedule_spread(Season(3, 9));
    std::cout << vect << std::endl;

    2020-2-1 - 2020-4-30: true
    2020-5-1 - 2020-7-31: true
    2020-8-1 - 2020-10-31: true
    2020-11-1 - 2021-1-31: false
    2021-2-1 - 2021-4-30: true
    2021-5-1 - 2021-7-31: true
    2021-8-1 - 2021-10-31: true
    2021-11-1 - 2022-1-31: false

Not everything is done yet (e.g. integrating this with treatments, documentation). The advantage is, it's in the library, so it would be standardized across rpops/r.pops.spread. Let me know what you think about this approach.