### PR TITLE
Fix Raster move constructor when not owning data

### DIFF
--- a/raster.hpp
+++ b/raster.hpp
@@ -130,7 +130,7 @@ public:
     }
 
     Raster(Raster&& other)
-        : owns_(true)
+        : owns_(other.owns_)
     {
         cols_ = other.cols_;
         rows_ = other.rows_;


### PR DESCRIPTION
The move was always setting new raster to own the data
instead of getting the ownership state from the moved object.
The move assignment was already implemented correctly.
The return_vector_of_rasters(T** data, ...) function fails in Valgrind
with 'Invalid free() / delete...' with previous version of constructor
(function included in test test_return_from_function_non_owner()).