### PR TITLE
Avoid creating a raster in simulation

### DIFF
--- a/simulation.hpp
+++ b/simulation.hpp
@@ -143,7 +143,7 @@ public:
      * `std::make_tuple(row, column)` fulfills this requirement.
      */
     template<typename DispersalKernel>
-    void disperse(IntegerRaster& dispersers,
+    void disperse(const IntegerRaster& dispersers,
                   IntegerRaster& susceptible, IntegerRaster& infected,
                   IntegerRaster& mortality_tracker,
                   const IntegerRaster& total_plants,

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -50,15 +50,13 @@ class Simulation
 private:
     int width;
     int height;
-    IntegerRaster dispersers;
     std::default_random_engine generator;
 public:
 
     Simulation(unsigned random_seed, const IntegerRaster &size)
         :
           width(size.cols()),
-          height(size.rows()),
-          dispersers(height, width)
+          height(size.rows())
     {
         generator.seed(random_seed);
     }
@@ -106,7 +104,8 @@ public:
         }
     }
 
-    void generate(const IntegerRaster& infected,
+    void generate(IntegerRaster& dispersers,
+                  const IntegerRaster& infected,
                   bool weather, const FloatRaster& weather_coefficient,
                   double reproductive_rate)
     {
@@ -144,7 +143,8 @@ public:
      * `std::make_tuple(row, column)` fulfills this requirement.
      */
     template<typename DispersalKernel>
-    void disperse(IntegerRaster& susceptible, IntegerRaster& infected,
+    void disperse(IntegerRaster& dispersers,
+                  IntegerRaster& susceptible, IntegerRaster& infected,
                   IntegerRaster& mortality_tracker,
                   const IntegerRaster& total_plants,
                   std::vector<std::tuple<int, int>>& outside_dispersers,

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -60,10 +60,11 @@ int main()
     int ns_res = 30;
     Simulation<Raster<int>, Raster<double>> simulation(42, infected);
     simulation.remove(infected, susceptible, temperature, lethal_temperature);
-    simulation.generate(infected, weather, weather_coefficient, reproductive_rate);
+    Raster<int> dispersers(infected.rows(), infected.cols());
+    simulation.generate(dispersers, infected, weather, weather_coefficient, reproductive_rate);
     RadialDispersalKernel kernel(ew_res, ns_res, dispersal_kernel,
                                  short_distance_scale);
-    simulation.disperse(susceptible, infected,
+    simulation.disperse(dispersers, susceptible, infected,
                         mortality_tracker, total_plants,
                         outside_dispersers, weather, weather_coefficient,
                         kernel);


### PR DESCRIPTION
Now caller needs to pass an existing dispersers raster to the simulation.
The con that it needs to exist and user needs to keep track of it,
but the pro is that it can be examined and used further or even modified
in between steps of simulation.

Consequently the dispersers are no longer a hidden detail, but part of what is
exposed to the caller.

The motivation is the avoiding of raster creation in simulation which makes
the simulation less dependent on particular raster class behavior,
in this case, a specific constructor (int, int) is no longer needed.