### PR TITLE
Improve Simulation class API and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,20 +32,25 @@ use `is` prefix like in `is_empty()` or `is_open()` especially
 when it would not be clear if it refers to an action or property,
 e.g. `empty()` versus `is_empty()`.
 
+For functions with a lot of parameters, long parameter names, or long
+type names, write one parameter per line.
+
 #### Member variables
 
 Use trailing underscore, i.e. `name_`, or nothing, i.e. `name` for
 member variables. No special marking is nice
 when used internally but not exposed to the outside
 world. However, if you need to distinguish a private member variable
-from a getter method, use trailing underscore for the private variable.
+from a getter method or a function parameter name, use trailing
+underscore for the private variable.
 The underscore, as opposed to using nothing, makes it easier to
 distinguish member variables from other variables when reading code
 of a method (and `this->` is not used).
 
 Do not use leading underscore, i.e. `_name`, like in Python because that might
-be reserved or used by standard library. Do not use leading letter m with out
-without underscore, i.e. `m_name` or `mname`, because it is harder to read.
+be reserved or used by standard library. Do not use leading letter `m`
+with or without underscore, i.e. `m_name` or `mname`, because it is
+harder to read.
 The trailing underscore is the closest thing to Python's marking of
 private members.
 
@@ -57,7 +62,7 @@ not `Type &value`.
 
 ### Documentation
 
-Don't document obvious things like in "this like assigns a variable"
+Don't document obvious things like in "this line assigns a variable"
 but keep in mind that people unfamiliar with C++ will read or even use
 or change the code, so point out some things which might be obvious to
 a C++ developer, but are unexpected coming from a different programming

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -43,32 +43,54 @@ namespace pops {
  *
  * The PoPS library offers a Raster template class to fill this role,
  * but other classes can be used as well.
+ *
+ * Template parameter RasterIndex is type used for maximum indices of
+ * the used rasters and should be the same as what the actual raster
+ * types are using. However, at the same time, comparison with signed
+ * type are perfomed and a signed type might be required in the future.
+ * A default is provided, but it can be changed in the future.
  */
-template<typename IntegerRaster, typename FloatRaster>
+template<typename IntegerRaster, typename FloatRaster, typename RasterIndex = int>
 class Simulation
 {
 private:
-    int width;
-    int height;
-    std::default_random_engine generator;
+    RasterIndex rows_;
+    RasterIndex cols_;
+    std::default_random_engine generator_;
 public:
 
-    Simulation(unsigned random_seed, const IntegerRaster &size)
+    /** Creates simulation object and seeds the internal random number generator.
+     *
+     * The same random number generator is used throughout the simulation
+     * and is seeded once at the beginning.
+     *
+     * The number or rows and columns needs to be the same as the size
+     * of rasters used with the Simulation object
+     * (potentially, it can be also smaller).
+     *
+     * @param random_seed Number to seed the random number generator
+     * @param rows Number of rows
+     * @param cols Number of columns
+     */
+    Simulation(unsigned random_seed,
+               RasterIndex rows,
+               RasterIndex cols)
         :
-          width(size.cols()),
-          height(size.rows())
+          rows_(rows),
+          cols_(cols)
     {
-        generator.seed(random_seed);
+        generator_.seed(random_seed);
     }
 
     Simulation() = delete;
 
-    void remove(IntegerRaster& infected, IntegerRaster& susceptible,
+    void remove(IntegerRaster& infected,
+                IntegerRaster& susceptible,
                 const FloatRaster& temperature,
                 double lethal_temperature)
     {
-        for (int i = 0; i < height; i++) {
-            for (int j = 0; j < width; j++) {
+        for (int i = 0; i < rows_; i++) {
+            for (int j = 0; j < cols_; j++) {
                 if (temperature(i, j) < lethal_temperature) {
                     susceptible(i, j) += infected(i, j);  // move infested/infected host back to suseptible pool
                     infected(i, j) = 0;  // remove all infestation/infection in the infected class
@@ -77,16 +99,19 @@ public:
         }
     }
     
-    void mortality(IntegerRaster& infected, double mortality_rate, 
-                   int current_year, int first_mortality_year,
-                   IntegerRaster& mortality, std::vector<IntegerRaster>& mortality_tracker_vector)
+    void mortality(IntegerRaster& infected,
+                   double mortality_rate,
+                   int current_year,
+                   int first_mortality_year,
+                   IntegerRaster& mortality,
+                   std::vector<IntegerRaster>& mortality_tracker_vector)
     {
         if (current_year >= (first_mortality_year)) {
             int mortality_current_year = 0;
             int max_year_index = current_year - first_mortality_year;
             
-            for (int i = 0; i < height; i++) {
-                for (int j = 0; j < width; j++) {
+            for (int i = 0; i < rows_; i++) {
+                for (int j = 0; j < cols_; j++) {
                     for (unsigned year_index = 0; year_index <= max_year_index; year_index++) {
                       int mortality_in_year_index = 0;
                         if (mortality_tracker_vector[year_index](i, j) > 0) {
@@ -104,14 +129,23 @@ public:
         }
     }
 
+    /** Generates dispersers based on infected
+     *
+     * @param[out] dispersers  (existing values are ignored)
+     * @param infected Currently infected hosts
+     * @param weather Whether to use the weather coefficient
+     * @param weather_coefficient Spatially explicit weather coefficient
+     * @param reproductive_rate reproductive rate (used unmodified when weather coefficient is not used)
+     */
     void generate(IntegerRaster& dispersers,
                   const IntegerRaster& infected,
-                  bool weather, const FloatRaster& weather_coefficient,
+                  bool weather,
+                  const FloatRaster& weather_coefficient,
                   double reproductive_rate)
     {
         double lambda = reproductive_rate;
-        for (int i = 0; i < height; i++) {
-            for (int j = 0; j < width; j++) {
+        for (int i = 0; i < rows_; i++) {
+            for (int j = 0; j < cols_; j++) {
                 if (infected(i, j) > 0) {
                     if (weather)
                         lambda = reproductive_rate * weather_coefficient(i, j); // calculate 
@@ -119,7 +153,7 @@ public:
                     std::poisson_distribution<int> distribution(lambda);
                     
                     for (int k = 0; k < infected(i, j); k++) {
-                        dispersers_from_cell += distribution(generator);
+                        dispersers_from_cell += distribution(generator_);
                     }
                     dispersers(i, j) = dispersers_from_cell;
                 }
@@ -132,7 +166,8 @@ public:
 
     /** Creates dispersal locations for the dispersing individuals
      *
-     * Assumes that the generate() function was called beforehand.
+     * Typically, the generate() function is called beforehand to
+     * create dispersers.
      *
      * DispersalKernel is callable object or function with one parameter
      * which is the random number engine (generator). The return value
@@ -144,25 +179,27 @@ public:
      */
     template<typename DispersalKernel>
     void disperse(const IntegerRaster& dispersers,
-                  IntegerRaster& susceptible, IntegerRaster& infected,
+                  IntegerRaster& susceptible,
+                  IntegerRaster& infected,
                   IntegerRaster& mortality_tracker,
                   const IntegerRaster& total_plants,
                   std::vector<std::tuple<int, int>>& outside_dispersers,
-                  bool weather, const FloatRaster& weather_coefficient,
+                  bool weather,
+                  const FloatRaster& weather_coefficient,
                   DispersalKernel& dispersal_kernel)
     {
         std::uniform_real_distribution<double> distribution_uniform(0.0, 1.0);
         int row;
         int col;
 
-        for (int i = 0; i < height; i++) {
-            for (int j = 0; j < width; j++) {
+        for (int i = 0; i < rows_; i++) {
+            for (int j = 0; j < cols_; j++) {
                 if (dispersers(i, j) > 0) {
                     for (int k = 0; k < dispersers(i, j); k++) {
 
-                        std::tie(row, col) = dispersal_kernel(generator, i, j);
+                        std::tie(row, col) = dispersal_kernel(generator_, i, j);
 
-                        if (row < 0 || row >= height || col < 0 || col >= width) {
+                        if (row < 0 || row >= rows_ || col < 0 || col >= cols_) {
                             // export dispersers dispersed outside of modeled area
                             outside_dispersers.emplace_back(std::make_tuple(row, col));
                             continue;
@@ -171,7 +208,7 @@ public:
                             double probability_of_establishment =
                                     (double)(susceptible(row, col)) /
                                     total_plants(row, col);
-                            double establishment_tester = distribution_uniform(generator);
+                            double establishment_tester = distribution_uniform(generator_);
 
                             if (weather)
                                 probability_of_establishment *= weather_coefficient(i, j);

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -50,6 +50,7 @@ int main()
     Raster<int> total_plants = {{15, 6}, {14, 15}};
     Raster<double> temperature = {{5, 0}, {0, 0}};
     Raster<double> weather_coefficient = {{0.6, 0.8}, {0.2, 0.8}};
+    Raster<int> dispersers(infected.rows(), infected.cols());
     std::vector<std::tuple<int, int>> outside_dispersers;
     DispersalKernelType dispersal_kernel = DispersalKernelType::Cauchy;
     bool weather = true;
@@ -58,9 +59,8 @@ int main()
     double short_distance_scale = 0.0;
     int ew_res = 30;
     int ns_res = 30;
-    Simulation<Raster<int>, Raster<double>> simulation(42, infected);
+    Simulation<Raster<int>, Raster<double>> simulation(42, infected.rows(), infected.cols());
     simulation.remove(infected, susceptible, temperature, lethal_temperature);
-    Raster<int> dispersers(infected.rows(), infected.cols());
     simulation.generate(dispersers, infected, weather, weather_coefficient, reproductive_rate);
     RadialDispersalKernel kernel(ew_res, ns_res, dispersal_kernel,
                                  short_distance_scale);


### PR DESCRIPTION
This is another small change in the API following #43.

Simulation constructor does not take a raster just to grab the size from it and requires rows and columns as parameters. This comes also with documentation for Simulation function parameters.

Simulation has now an optional template parameter for index type. This seemed natural for the constructor parameters and member variables since it is bind to the raster classes, but the relationship with type (int) used internally and in dispersal kernel may need to be revised since they are using specific type and any generic type needs to be signed for dispersal kernel mechanism to work properly, so, for example, the typical C++ standard library (STL) index (size_t) is not usable.

A lot of lines are touched by renaming the member/private variables (from width-height to rows-cols terminology and order) and adding the trailing underscore.

The changes for rpops and r.pops.spread should be just trivial, here is an example from the test suite:

```
- Simulation<Raster<int>, Raster<double>> simulation(42, infected);
+ Simulation<Raster<int>, Raster<double>> simulation(42, infected.rows(), infected.cols());
```