### PR TITLE
Add SEI functionality by tracking exposted hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project should be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2020-04-16 - SEI model
+
+### Added
+
+- Exposed host tracking with latency period to run SEI models. (Vaclav Petras)
+
+### Changed
+
+- Step numbering is now expected to start at zero. (Vaclav Petras)
+
 ## 2020-01-04 - Movement Module
 
 ### Added

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -133,11 +133,11 @@ public:
      * @param rows Number of rows
      * @param cols Number of columns
      */
-    Simulation(ModelType model_type,
-               unsigned latency_period,
-               unsigned random_seed,
+    Simulation(unsigned random_seed,
                RasterIndex rows,
-               RasterIndex cols
+               RasterIndex cols,
+               ModelType model_type = ModelType::SusceptibleInfected,
+               unsigned latency_period = 0
                )
         :
           rows_(rows),

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -435,7 +435,7 @@ public:
             IntegerRaster& mortality_tracker)
     {
         if (model_type_ == ModelType::SusceptibleExposedInfected) {
-            if (step > latency_period_) {
+            if (step >= latency_period_) {
                 // Oldest item needs to be in the front
                 auto& oldest = exposed.front();
                 // Move hosts to infected raster

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -128,7 +128,7 @@ public:
      * (potentially, it can be also smaller).
      *
      * @param model_type Type of the model (SI or SEI)
-     * @param latency_period Lenght of the latency period in steps
+     * @param latency_period Length of the latency period in steps
      * @param random_seed Number to seed the random number generator
      * @param rows Number of rows
      * @param cols Number of columns
@@ -308,7 +308,8 @@ public:
     /** Creates dispersal locations for the dispersing individuals
      *
      * Depending on what data is provided as the *exposed_or_infected*
-     * paramater, this function can be part of as S to E step or S to I.
+     * paramater, this function can be part of the S to E step or the
+     * S to I step.
      *
      * Typically, the generate() function is called beforehand to
      * create dispersers. In SEI model, the infect() function is
@@ -393,7 +394,7 @@ public:
      * are left intact for other models.
      *
      * The exposed vector are the hosts exposed in the previous steps.
-     * The lenght of the vector is the number of steps of the latency
+     * The length of the vector is the number of steps of the latency
      * period plus one. Before the first latency period is over,
      * the E to I transition won't happen because no item in the exposed
      * vector is old enough to become infected.
@@ -416,7 +417,7 @@ public:
      * tracker). They are removed from the exposed item and this item
      * is moved to the back of the vector.
      *
-     * Like in disperse(), there is no distiction between *infected*
+     * Like in disperse(), there is no distinction between *infected*
      * and *mortality_tracker*, but different usage is expected outside
      * of this function.
      *

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -35,7 +35,7 @@ namespace pops {
  * element is moved to the back.
  */
 template <typename Container>
-void rotate_left(Container& container)
+void rotate_left_by_one(Container& container)
 {
     std::rotate(container.begin(), container.begin() + 1, container.end());
 }
@@ -415,7 +415,7 @@ public:
                 // elements go one position to the left
                 // new oldest goes to the front
                 // old oldest goes to the back
-                rotate_left(exposed);
+                rotate_left_by_one(exposed);
             }
         }
         else if (model_type_ == ModelType::SusceptibleInfected) {

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -425,12 +425,13 @@ public:
      * @param mortality_tracker Newly infected hosts
      */
     void infect(
+            unsigned step,
             std::vector<IntegerRaster>& exposed,
             IntegerRaster& infected,
             IntegerRaster& mortality_tracker)
     {
         if (model_type_ == ModelType::SusceptibleExposedInfected) {
-            if (exposed.size() >= latency_period_ + 1) {
+            if (step > latency_period_) {
                 // Oldest item needs to be in the front
                 auto& oldest = exposed.front();
                 // Move hosts to infected raster
@@ -485,6 +486,7 @@ public:
      */
     template<typename DispersalKernel>
     void disperse_and_infect(
+            unsigned step,
             const IntegerRaster& dispersers,
             IntegerRaster& susceptible,
             std::vector<IntegerRaster>& exposed,
@@ -500,7 +502,10 @@ public:
         if (model_type_ == ModelType::SusceptibleExposedInfected)
             // The empty - not yet exposed - raster is in the back
             // and will become yougest exposed one.
-            infected_or_exposed = exposed.back();
+            if (step > latency_period_)
+                infected_or_exposed = exposed.back();
+            else
+                infected_or_exposed = exposed[step];
         this->disperse(
                     dispersers,
                     susceptible,
@@ -512,7 +517,7 @@ public:
                     weather_coefficient,
                     dispersal_kernel);
         if (model_type_ == ModelType::SusceptibleExposedInfected) {
-            this->infect(exposed, infected, mortality_tracker);
+            this->infect(step, exposed, infected, mortality_tracker);
         }
     }
 };

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -126,15 +126,18 @@ public:
      * of rasters used with the Simulation object
      * (potentially, it can be also smaller).
      *
+     * @param model_type Type of the model (SI or SEI)
+     * @param latency_period Lenght of the latency period in steps
      * @param random_seed Number to seed the random number generator
      * @param rows Number of rows
      * @param cols Number of columns
      */
-    Simulation(unsigned random_seed,
+    Simulation(ModelType model_type,
+               unsigned latency_period,
+               unsigned random_seed,
                RasterIndex rows,
-               RasterIndex cols,
-               ModelType model_type,
-               unsigned latency_period)
+               RasterIndex cols
+               )
         :
           rows_(rows),
           cols_(cols),

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -312,7 +312,7 @@ public:
      * S to I step.
      *
      * Typically, the generate() function is called beforehand to
-     * create dispersers. In SEI model, the infect() function is
+     * create dispersers. In SEI model, the infect_exposed() function is
      * typically called afterwards.
      *
      * DispersalKernel is callable object or function with one parameter
@@ -429,7 +429,7 @@ public:
      * @param infected Infected hosts
      * @param mortality_tracker Newly infected hosts
      */
-    void infect(
+    void infect_exposed(
             unsigned step,
             std::vector<IntegerRaster>& exposed,
             IntegerRaster& infected,
@@ -456,14 +456,15 @@ public:
             // no-op
         }
         else {
-            throw std::runtime_error("Unknown ModelType value in Simulation::infect()");
+            throw std::runtime_error(
+                        "Unknown ModelType value in Simulation::infect_exposed()");
         }
     }
 
     /** Disperse, expose, and infect based on dispersers
      *
-     * This function wraps disperse() and infect() for use in SI and SEI
-     * models.
+     * This function wraps disperse() and infect_exposed() for use in SI
+     * and SEI models.
      *
      * In case of SEI model, before calling this function, last item in
      * the exposed vector needs to be ready to be used for exposure,
@@ -474,17 +475,17 @@ public:
      * and each raster is empty, i.e., does not conatain any hosts
      * (all values set to zero).
      *
-     * See the infect() function for the details about exposed vector,
-     * its size, and its items.
+     * See the infect_exposed() function for the details about exposed
+     * vector, its size, and its items.
      *
-     * See disperse() and infect() for a detailed list of parameters
-     * and behavior. The disperse() parameter documentation can be
-     * applied as is except that disperse() function's parameter
+     * See disperse() and infect_exposed() for a detailed list of
+     * parameters and behavior. The disperse() parameter documentation
+     * can be applied as is except that disperse() function's parameter
      * *exposed_or_infested* is expected to change based on the context
      * while this function's parameter *infected* is always the infected
      * individuals. Besides parameters from disperse(), this function
      * has parameter *exposed* which is the same as the one from the
-     * infect() function.
+     * infect_exposed() function.
      */
     template<typename DispersalKernel>
     void disperse_and_infect(
@@ -517,7 +518,7 @@ public:
                     weather_coefficient,
                     dispersal_kernel);
         if (model_type_ == ModelType::SusceptibleExposedInfected) {
-            this->infect(step, exposed, infected, mortality_tracker);
+            this->infect_exposed(step, exposed, infected, mortality_tracker);
         }
     }
 };

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -394,19 +394,18 @@ public:
      *
      * The exposed vector are the hosts exposed in the previous steps.
      * The lenght of the vector is the number of steps of the latency
-     * period plus one when the simulation is in the steps beyond the
-     * first latency period. Before that, exposed vector lenght is
-     * smaller than latency period plus one and the E to I transition
-     * won't happen because no item in the exposed vector is old enough
-     * to become infected.
+     * period plus one. Before the first latency period is over,
+     * the E to I transition won't happen because no item in the exposed
+     * vector is old enough to become infected.
      *
      * The position of the items in the exposed vector determines their
      * age, i.e., for how long the hosts are exposed. The oldest item
      * is at the front and youngest at the end. After the first latency
      * period, this needs to be true before the function is called and
      * it is true after the function
-     * finished with the difference that the last item is empty in the
-     * sense that it does not contain any hosts.
+     * finished with the difference that after the function is called,
+     * the last item is empty in the sense that it does not contain any
+     * hosts.
      *
      * When the E to I transition happens, hosts from the oldest item
      * in the exposed vector are moved to the infected (and mortality
@@ -420,7 +419,8 @@ public:
      * The raster class used with the simulation class needs to support
      * `.fill()` method for this function to work.
      *
-     * @param exposed Exposed hosts
+     * @param step Step in the simulation (>=0)
+     * @param exposed Vector of exposed hosts
      * @param infected Infected hosts
      * @param mortality_tracker Newly infected hosts
      */
@@ -463,14 +463,16 @@ public:
      * In case of SEI model, before calling this function, last item in
      * the exposed vector needs to be ready to be used for exposure,
      * i.e., typically, it should be empty in the sense that there are
-     * no hosts in the raster. This is the state this function produces
-     * when executed after the first latency period is over. Before
-     * that, a new item should be added to the exposed vector:
+     * no hosts in the raster. This is normally taken care of by a
+     * previous call to this function. The initial state of the exposed
+     * vector should be such that size is latency period in steps plus 1
+     * and each raster is empty, i.e., does not conatain any hosts
+     * (all values set to zero).
      *
-     * ```
-     * if (exposed_vector.size() < latency_period_steps + 1)
-     *     exposed_vector.emplace_back(rows, cols, 0);
-     * ```
+     * Before the first latency period is over, the function uses each
+     * item in the vector starting with the first item continuing to
+     * the back of the vector. After the first latency period, the last
+     * item is always used.
      *
      * See the infect() function for the details about exposed vector,
      * its size, and its items.

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -21,14 +21,70 @@
 
 #include <cmath>
 #include <tuple>
+#include <vector>
 #include <random>
-
-using std::cerr;
-using std::endl;
+#include <string>
+#include <stdexcept>
 
 namespace pops {
 
+/** Rotate elements in a container to the left by one
+ *
+ * Rotates (moves) elements in a container to the left (anticlockwise)
+ * by one. The second element is moved to the front and the first
+ * element is moved to the back.
+ */
+template <typename Container>
+void rotate_left(Container& container)
+{
+    std::rotate(container.begin(), container.begin() + 1, container.end());
+}
+
+/** The type of a epidemiological model (SI or SEI)
+ */
+enum class ModelType {
+    SusceptibleInfected,  ///< SI (susceptible - infected)
+    SusceptibleExposedInfected  ///< SEI (susceptible - exposed - infected)
+};
+
+/*! Get a corresponding enum value for a string which is a model type name.
+ *
+ * Throws an std::invalid_argument exception if the value was not
+ * found or is not supported (which is the same thing).
+ */
+inline
+ModelType model_type_from_string(const std::string& text)
+{
+    if (text == "SI" || text == "SusceptibleInfected"
+            || text == "susceptible-infected"
+            || text == "susceptible_infected")
+        return ModelType::SusceptibleInfected;
+    else if (text == "SEI" || text == "SusceptibleExposedInfected"
+             || text == "susceptible-exposed-infected"
+             || text == "susceptible_exposed_infected")
+        return ModelType::SusceptibleExposedInfected;
+    else
+        throw std::invalid_argument("model_type_from_string: Invalid"
+                                    " value '" + text +"' provided");
+}
+
+/*! Overload which allows to pass C-style string which is nullptr (NULL)
+ *
+ * @see model_type_from_string(const std::string& text)
+ */
+inline
+ModelType model_type_from_string(const char* text)
+{
+    // call the string version
+    return model_type_from_string(text ? std::string(text)
+                                       : std::string());
+}
+
 /*! The main class to control the spread simulation.
+ *
+ * The Simulation class handles the mechanics of the model, but the
+ * timing of the events or steps should be handled outside of this
+ * class unless noted otherwise.
  *
  * The template parameters IntegerRaster and FloatRaster are raster
  * image or matrix types. Any 2D numerical array should work as long as
@@ -56,6 +112,8 @@ class Simulation
 private:
     RasterIndex rows_;
     RasterIndex cols_;
+    ModelType model_type_;
+    unsigned latency_period_;
     std::default_random_engine generator_;
 public:
 
@@ -74,10 +132,14 @@ public:
      */
     Simulation(unsigned random_seed,
                RasterIndex rows,
-               RasterIndex cols)
+               RasterIndex cols,
+               ModelType model_type,
+               unsigned latency_period)
         :
           rows_(rows),
-          cols_(cols)
+          cols_(cols),
+          model_type_(model_type),
+          latency_period_(latency_period)
     {
         generator_.seed(random_seed);
     }
@@ -241,8 +303,12 @@ public:
 
     /** Creates dispersal locations for the dispersing individuals
      *
+     * Depending on what data is provided as the *exposed_or_infected*
+     * paramater, this function can be part of as S to E step or S to I.
+     *
      * Typically, the generate() function is called beforehand to
-     * create dispersers.
+     * create dispersers. In SEI model, the infect() function is
+     * typically called afterwards.
      *
      * DispersalKernel is callable object or function with one parameter
      * which is the random number engine (generator). The return value
@@ -251,11 +317,21 @@ public:
      * form of a tuple with row and column so that std::tie() is usable
      * on the result, i.e. function returning
      * `std::make_tuple(row, column)` fulfills this requirement.
+     *
+     * @param[in] dispersers Dispersing individuals ready to be dispersed
+     * @param[in,out] susceptible Susceptible hosts
+     * @param[in,out] exposed_or_infected Exposed or infected hosts
+     * @param[in,out] mortality_tracker Newly infected hosts (if applicable)
+     * @param[in] total_plants All plants in the landscape
+     * @param[in,out] outside_dispersers Dispersers escaping the rasters
+     * @param weather Whether or not weather coefficients should be used
+     * @param[in] weather_coefficient Weather coefficient for each location
+     * @param dispersal_kernel Dispersal kernel to move dispersers
      */
     template<typename DispersalKernel>
     void disperse(const IntegerRaster& dispersers,
                   IntegerRaster& susceptible,
-                  IntegerRaster& infected,
+                  IntegerRaster& exposed_or_infected,
                   IntegerRaster& mortality_tracker,
                   const IntegerRaster& total_plants,
                   std::vector<std::tuple<int, int>>& outside_dispersers,
@@ -288,9 +364,17 @@ public:
                             if (weather)
                                 probability_of_establishment *= weather_coefficient(i, j);
                             if (establishment_tester < probability_of_establishment) {
-                                infected(row, col) += 1;
-                                mortality_tracker(row, col) += 1;
+                                exposed_or_infected(row, col) += 1;
                                 susceptible(row, col) -= 1;
+                                if (model_type_ == ModelType::SusceptibleInfected) {
+                                    mortality_tracker(row, col) += 1;
+                                }
+                                else if (model_type_ == ModelType::SusceptibleExposedInfected) {
+                                    // no-op
+                                }
+                                else {
+                                    throw std::runtime_error("Unknown ModelType value in Simulation::disperse()");
+                                }
                             }
                         }
                     }
@@ -299,6 +383,90 @@ public:
         }
     }
 
+    /** Infect exposed hosts (E to I step)
+     *
+     * Applicable to SEI model, no-operation otherwise, i.e., parameters
+     * are left intact for other models.
+     *
+     * Like in disperse(), there is no distiction between *infected*
+     * and *mortality_tracker*, but different usage is expected outside
+     * of this function.
+     *
+     * @param exposed Exposed hosts
+     * @param infected Infected hosts
+     * @param mortality_tracker Newly infected hosts
+     * @returns Index of oldest exposed raster in the next step
+     */
+    void infect(
+            std::vector<IntegerRaster>& exposed,
+            IntegerRaster& infected,
+            IntegerRaster& mortality_tracker)
+    {
+        if (model_type_ == ModelType::SusceptibleExposedInfected) {
+            if (exposed.size() >= latency_period_ + 1) {
+                auto& oldest = exposed.front();
+                infected += oldest;
+                mortality_tracker += oldest;
+                // the raster class needs to support .fill()
+                oldest.fill(0);
+                // elements go one position to the left
+                // new oldest goes to the front
+                // old oldest goes to the back
+                rotate_left(exposed);
+            }
+        }
+        else if (model_type_ == ModelType::SusceptibleInfected) {
+            // no-op
+        }
+        else {
+            throw std::runtime_error("Unknown ModelType value in Simulation::infect()");
+        }
+    }
+
+    /** Disperse, expose, and infect based on dispersers
+     *
+     * This function wraps disperse() and infect() for use in SI and SEI
+     * models.
+     *
+     * See disperse() and infect() for a detailed list of parameters
+     * and behavior. The disperse() parameter documentation can be
+     * applied as is except that disperse() function's parameter
+     * *exposed_or_infested* is expected to change based on the context
+     * while this function's parameter *infected* is always the infected
+     * individuals. Besides parameters from disperse(), this function
+     * has parameter *exposed* which is the same as the one from the
+     * infect() function.
+     */
+    template<typename DispersalKernel>
+    void disperse_and_infect(
+            const IntegerRaster& dispersers,
+            IntegerRaster& susceptible,
+            std::vector<IntegerRaster>& exposed,
+            IntegerRaster& infected,
+            IntegerRaster& mortality_tracker,
+            const IntegerRaster& total_plants,
+            std::vector<std::tuple<int, int>>& outside_dispersers,
+            bool weather,
+            const FloatRaster& weather_coefficient,
+            DispersalKernel& dispersal_kernel)
+    {
+        auto& infected_or_exposed = infected;
+        if (model_type_ == ModelType::SusceptibleExposedInfected)
+            infected_or_exposed = exposed.back();
+        this->disperse(
+                    dispersers,
+                    susceptible,
+                    infected_or_exposed,
+                    mortality_tracker,
+                    total_plants,
+                    outside_dispersers,
+                    weather,
+                    weather_coefficient,
+                    dispersal_kernel);
+        if (model_type_ == ModelType::SusceptibleExposedInfected) {
+            this->infect(exposed, infected, mortality_tracker);
+        }
+    }
 };
 
 } // namespace pops

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -142,7 +142,6 @@ int test_calling_all_functions()
                         outside_dispersers, weather, weather_coefficient,
                         kernel);
     cout << "outside_dispersers: " << outside_dispersers.size() << endl;
-    cout << outside_dispersers.size() << endl;
     return 0;
 }
 
@@ -151,6 +150,7 @@ int main()
     int ret = 0;
 
     ret += test_rotate_left_by_one({1}, {2});
+    ret += test_rotate_left_by_one({1}, {1});
     ret += test_rotate_left_by_one({1, 2}, {2, 1});
     ret += test_rotate_left_by_one({1, 2, 3, 4, 5}, {2, 3, 4, 5, 1});
 

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -43,11 +43,21 @@ using std::endl;
 
 using namespace pops;
 
+void print_vector(std::vector<int> v)
+{
+    for (auto i : v) {
+        cout << i;
+    }
+    cout << "\n";
+}
+
 int test_rotate_left_by_one(std::vector<int> a, std::vector<int> b)
 {
     rotate_left_by_one(a);
     if (a != b) {
         cout << "Rotated vector not correct\n";
+        print_vector(a);
+        print_vector(b);
         return 1;
     }
     return 0;
@@ -149,8 +159,7 @@ int main()
 {
     int ret = 0;
 
-    ret += test_rotate_left_by_one({1}, {2});
-    ret += test_rotate_left_by_one({1}, {1});
+    ret += test_rotate_left_by_one({2}, {2});
     ret += test_rotate_left_by_one({1, 2}, {2, 1});
     ret += test_rotate_left_by_one({1, 2, 3, 4, 5}, {2, 3, 4, 5, 1});
 

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -43,6 +43,16 @@ using std::endl;
 
 using namespace pops;
 
+int test_rotate_left_by_one(std::vector<int> a, std::vector<int> b)
+{
+    rotate_left_by_one(a);
+    if (a != b) {
+        cout << "Rotated vector not correct\n";
+        return 1;
+    }
+    return 0;
+}
+
 int test_with_neighbor_kernel()
 {
     Raster<int> infected = {{5, 0}, {0, 0}};
@@ -132,12 +142,17 @@ int test_calling_all_functions()
                         outside_dispersers, weather, weather_coefficient,
                         kernel);
     cout << "outside_dispersers: " << outside_dispersers.size() << endl;
+    cout << outside_dispersers.size() << endl;
     return 0;
 }
 
 int main()
 {
     int ret = 0;
+
+    ret += test_rotate_left_by_one({1}, {2});
+    ret += test_rotate_left_by_one({1, 2}, {2, 1});
+    ret += test_rotate_left_by_one({1, 2, 3, 4, 5}, {2, 3, 4, 5, 1});
 
     ret += test_calling_all_functions();
     ret += test_with_neighbor_kernel();

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -43,7 +43,8 @@ using std::endl;
 
 using namespace pops;
 
-void print_vector(std::vector<int> v)
+template <typename T>
+void print_vector(const std::vector<T>& v)
 {
     for (auto i : v) {
         cout << i;

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -89,8 +89,15 @@ int test_with_neighbor_kernel()
     std::vector<std::tuple<int, int>> outside_dispersers;
     bool weather = false;
     double reproductive_rate = 2;
+    unsigned latency_period_steps = 2;
     DeterministicNeighborDispersalKernel kernel(Direction::E);
-    Simulation<Raster<int>, Raster<double>> simulation(42, infected.rows(), infected.cols());
+    Simulation<Raster<int>, Raster<double>> simulation(
+                model_type_from_string("SI"),
+                latency_period_steps,
+                42,
+                infected.rows(),
+                infected.cols()
+                );
     dispersers = reproductive_rate * infected;
     // cout << dispersers;
     simulation.disperse(dispersers, susceptible, exposed,

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -93,8 +93,6 @@ int test_with_neighbor_kernel()
     unsigned latency_period_steps = 2;
     DeterministicNeighborDispersalKernel kernel(Direction::E);
     Simulation<Raster<int>, Raster<double>> simulation(
-                model_type_from_string("SI"),
-                latency_period_steps,
                 42,
                 infected.rows(),
                 infected.cols()
@@ -187,11 +185,11 @@ int test_with_sei()
 
     DeterministicNeighborDispersalKernel kernel(Direction::E);
     Simulation<Raster<int>, Raster<double>> simulation(
-                model_type_from_string("SEI"),
-                latency_period_steps,
                 42,
                 infected.rows(),
-                infected.cols()
+                infected.cols(),
+                model_type_from_string("SEI"),
+                latency_period_steps
                 );
     dispersers = reproductive_rate * infected;
     int step = 0;
@@ -319,8 +317,6 @@ int test_calling_all_functions()
     std::vector<std::vector<int>> movements = {{0, 0, 1, 1, 2}, {0, 1, 0, 0, 3}};
     std::vector<unsigned> movement_schedule = {1, 1};
     Simulation<Raster<int>, Raster<double>> simulation(
-                model_type_from_string("SI"),
-                latency_period_steps,
                 seed,
                 infected.rows(),
                 infected.cols());

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -82,15 +82,13 @@ int test_with_neighbor_kernel()
     Raster<double> temperature = {{5, 0}, {0, 0}};
     Raster<double> weather_coefficient = {{0, 0}, {0, 0}};
 
-    Raster<int> expected_exposed = {{0, 10}, {0, 0}};
-    Raster<int> expected_mortality_tracker = expected_exposed;
+    Raster<int> expected_mortality_tracker = {{0, 10}, {0, 0}};
+    auto expected_infected = expected_mortality_tracker + infected;
 
-    Raster<int> exposed(infected.rows(), infected.cols(), 0);
     Raster<int> dispersers(infected.rows(), infected.cols());
     std::vector<std::tuple<int, int>> outside_dispersers;
     bool weather = false;
     double reproductive_rate = 2;
-    unsigned latency_period_steps = 2;
     DeterministicNeighborDispersalKernel kernel(Direction::E);
     Simulation<Raster<int>, Raster<double>> simulation(
                 42,
@@ -99,7 +97,7 @@ int test_with_neighbor_kernel()
                 );
     dispersers = reproductive_rate * infected;
     // cout << dispersers;
-    simulation.disperse(dispersers, susceptible, exposed,
+    simulation.disperse(dispersers, susceptible, infected,
                         mortality_tracker, total_plants,
                         outside_dispersers, weather, weather_coefficient,
                         kernel);
@@ -107,8 +105,8 @@ int test_with_neighbor_kernel()
         cout << "There are outside_dispersers (" << outside_dispersers.size() << ") but there should be none\n";
         return 1;
     }
-    if (exposed != expected_exposed) {
-        cout << "Neighbor kernel test (actual, expected):\n" << exposed << "  !=\n" << expected_exposed << "\n";
+    if (infected != expected_infected) {
+        cout << "Neighbor kernel test infected (actual, expected):\n" << infected << "  !=\n" << expected_infected << "\n";
         return 1;
     }
     if (mortality_tracker != expected_mortality_tracker) {

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -110,10 +110,17 @@ int test_calling_all_functions()
     int ew_res = 30;
     int ns_res = 30;
     unsigned step = 1;
+    unsigned latency_period_steps = 2;
     unsigned last_index = 0;
+    int seed = 42;
     std::vector<std::vector<int>> movements = {{0, 0, 1, 1, 2}, {0, 1, 0, 0, 3}};
     std::vector<unsigned> movement_schedule = {1, 1};
-    Simulation<Raster<int>, Raster<double>> simulation(42, infected.rows(), infected.cols());
+    Simulation<Raster<int>, Raster<double>> simulation(
+                model_type_from_string("SI"),
+                latency_period_steps,
+                seed,
+                infected.rows(),
+                infected.cols());
     simulation.remove(infected, susceptible, temperature, lethal_temperature);
     simulation.generate(dispersers, infected, weather, weather_coefficient, reproductive_rate);
     RadialDispersalKernel kernel(ew_res, ns_res, dispersal_kernel,


### PR DESCRIPTION
Exposed are tracked similarly to mortality in a vector of rasters where the position determines the age. A new wrapper function is provided to wrap the current disperse call combined
with the E to I step of SEI model.

The result of SI is identical with SEI with latency period of zero steps. Using the original API also gives the same result as using the new API with SI. There is a test for that and for mode detailed test for individual steps with latency period 3 steps.

The step is now parameter of relevant functions in Simulation which was not the case before, but this simplifies the API for SEI and we already need year for mortality, so Simulation already needs to know about the time/step at some places. The needs of Simulation introduce another assumption about the step counting: Now the step counter needs to start at zero (this does not seem to be a requirement of scheduler code right now).

One issue to discuss is naming of the functions which is not as important for the wrappers (which wrap on higher level), but it is useful for documentation and possibly for publications. The functions in Simulation class don't fit into the SEI terminology as the transitions between these categories is different from the mechanisms which the functions are implementing, namely the new function currently named `infect()` is doing nothing SI model, but it is doing E to I transition in SEI. An already existing function named `disperse()` is doing S to I transition in SI, but S to E in SEI. The problem is basically the two new functions, `infect()` and the higher level function `disperse_and_infect()` which will now be the primary interface instead of `disperse()`. If we have a quick solution for now, let's do it in this PR, but otherwise, I will just open a separate ticket for that. I'm mentioning it here to avoid confusion, esp. about the `infect()` function.

There are comments in the code itself and for Doxygen documentation and test, so please see further explanations there.