### PR TITLE
Helper functions for parsing input + scheduler fix

### DIFF
--- a/scheduling.hpp
+++ b/scheduling.hpp
@@ -95,6 +95,9 @@ public:
      * The steps can be e.g. 1 day, 3 months, 2 weeks.
      * Step is scheduled if start date of an interval is
      * within [start, end] even if end date of the step is outside.
+     * That means the entire interval is contained in the simulation steps
+     * even when only part of it was requested.
+     *
      * @param start simulation start date
      * @param end simulation end date
      * @param simulation_unit simulation unit

--- a/scheduling.hpp
+++ b/scheduling.hpp
@@ -367,11 +367,11 @@ inline std::vector<bool> output_schedule_from_string(const Scheduler &scheduler,
     std::invalid_argument exception("Output frequency and simulation step are incompatible");
     std::tie(sim_n, sim_unit) = scheduler.get_step_length();
     if (!frequency.empty()) {
-        if (frequency == "year")
+        if (frequency == "year" || frequency == "yearly")
             return scheduler.schedule_action_end_of_year();
-        else if (frequency == "month")
+        else if (frequency == "month" || frequency == "monthly")
             return scheduler.schedule_action_monthly();
-        else if (frequency == "week") {
+        else if (frequency == "week" || frequency == "weekly") {
             if (sim_unit == StepUnit::Day) {
                 if (sim_n == 1)
                     return scheduler.schedule_action_nsteps(7);
@@ -388,7 +388,7 @@ inline std::vector<bool> output_schedule_from_string(const Scheduler &scheduler,
             }
             throw exception;
         }
-        else if (frequency == "day") {
+        else if (frequency == "day" || frequency == "daily") {
             if (sim_unit == StepUnit::Day && sim_n == 1)
                  return scheduler.schedule_action_nsteps(1);
             else

--- a/scheduling.hpp
+++ b/scheduling.hpp
@@ -66,6 +66,8 @@ public:
      * Scheduler creates a vector of simulation steps
      * based on start, end date, unit and number of units.
      * The steps can be e.g. 1 day, 3 months, 2 weeks.
+     * Step is scheduled if start date of an interval is
+     * within [start, end] even if end date of the step is outside.
      * @param start simulation start date
      * @param end simulation end date
      * @param simulation_unit simulation unit
@@ -89,7 +91,7 @@ public:
         
         Date date(start_);
         unsigned step = 0;
-        while (date < end_) {
+        while (date <= end_) {
             Date start(date);
             increase_date(date);
             Date end(date);

--- a/test_scheduling.cpp
+++ b/test_scheduling.cpp
@@ -313,14 +313,14 @@ int test_output_schedule_from_string()
     Date end(2020, 1, 28);
 
     Scheduler scheduling(st, end, StepUnit::Week, 1);
-    std::vector<bool> out = output_schedule_from_string(scheduling, "week", 0);
+    std::vector<bool> out = output_schedule_from_string(scheduling, "week");
     if (get_number_of_scheduled_actions(out) != 4)
         num_errors++;
     out = output_schedule_from_string(scheduling, "every_n_steps", 2);
     if (get_number_of_scheduled_actions(out) != 2)
         num_errors++;
     try {
-        out = output_schedule_from_string(scheduling, "day", 0);
+        out = output_schedule_from_string(scheduling, "day");
         num_errors++;
     }
     catch (std::invalid_argument) {
@@ -328,10 +328,10 @@ int test_output_schedule_from_string()
     }
 
     Scheduler scheduling2(st, end, StepUnit::Day, 1);
-    out = output_schedule_from_string(scheduling2, "week", 0);
+    out = output_schedule_from_string(scheduling2, "week");
     if (get_number_of_scheduled_actions(out) != 4)
         num_errors++;
-    out = output_schedule_from_string(scheduling2, "day", 0);
+    out = output_schedule_from_string(scheduling2, "day");
     if (get_number_of_scheduled_actions(out) != 28)
         num_errors++;
     out = output_schedule_from_string(scheduling2, "every_n_steps", 7);
@@ -340,7 +340,7 @@ int test_output_schedule_from_string()
 
     Scheduler scheduling3(st, end, StepUnit::Week, 2);
     try {
-        out = output_schedule_from_string(scheduling3, "week", 0);
+        out = output_schedule_from_string(scheduling3, "week");
         num_errors++;
     }
     catch (std::invalid_argument) {
@@ -349,7 +349,7 @@ int test_output_schedule_from_string()
     out = output_schedule_from_string(scheduling3, "every_n_steps", 2);
     if (get_number_of_scheduled_actions(out) != 1)
         num_errors++;
-    out = output_schedule_from_string(scheduling3, "month", 0);
+    out = output_schedule_from_string(scheduling3, "month");
     if (get_number_of_scheduled_actions(out) != 0)
         num_errors++;
 

--- a/test_scheduling.cpp
+++ b/test_scheduling.cpp
@@ -24,6 +24,7 @@
  */
 
 #include <vector>
+#include <tuple>
 
 #include "scheduling.hpp"
 #include "date.hpp"
@@ -283,6 +284,98 @@ int test_get_number_of_scheduled_actions()
     return num_errors;
 }
 
+int test_unit_enum_from_string()
+{
+    int num_errors = 0;
+    if (step_unit_enum_from_string("day") != StepUnit::Day)
+        num_errors++;
+    if (step_unit_enum_from_string("week") != StepUnit::Week)
+        num_errors++;
+    if (step_unit_enum_from_string("month") != StepUnit::Month)
+        num_errors++;
+    try {
+        step_unit_enum_from_string("invalid_input");
+        num_errors++;
+    }
+    catch (std::invalid_argument) {
+        // OK
+    }
+    catch (...) {
+        num_errors++;
+    }
+    return num_errors;
+}
+
+int test_output_schedule_from_string()
+{
+    int num_errors = 0;
+    Date st(2020, 1, 1);
+    Date end(2020, 1, 28);
+
+    Scheduler scheduling(st, end, StepUnit::Week, 1);
+    std::vector<bool> out = output_schedule_from_string(scheduling, "week", 0);
+    if (get_number_of_scheduled_actions(out) != 4)
+        num_errors++;
+    out = output_schedule_from_string(scheduling, "every_n_steps", 2);
+    if (get_number_of_scheduled_actions(out) != 2)
+        num_errors++;
+    try {
+        out = output_schedule_from_string(scheduling, "day", 0);
+        num_errors++;
+    }
+    catch (std::invalid_argument) {
+        // OK
+    }
+
+    Scheduler scheduling2(st, end, StepUnit::Day, 1);
+    out = output_schedule_from_string(scheduling2, "week", 0);
+    if (get_number_of_scheduled_actions(out) != 4)
+        num_errors++;
+    out = output_schedule_from_string(scheduling2, "day", 0);
+    if (get_number_of_scheduled_actions(out) != 28)
+        num_errors++;
+    out = output_schedule_from_string(scheduling2, "every_n_steps", 7);
+    if (get_number_of_scheduled_actions(out) != 4)
+        num_errors++;
+
+    Scheduler scheduling3(st, end, StepUnit::Week, 2);
+    try {
+        out = output_schedule_from_string(scheduling3, "week", 0);
+        num_errors++;
+    }
+    catch (std::invalid_argument) {
+        // OK
+    }
+    out = output_schedule_from_string(scheduling3, "every_n_steps", 2);
+    if (get_number_of_scheduled_actions(out) != 1)
+        num_errors++;
+    out = output_schedule_from_string(scheduling3, "month", 0);
+    if (get_number_of_scheduled_actions(out) != 0)
+        num_errors++;
+
+    out = output_schedule_from_string(scheduling3, "", 0);
+    if (get_number_of_scheduled_actions(out) != 0)
+        num_errors++;
+    return num_errors;
+}
+
+
+int test_get_step_length()
+{
+    int num_errors = 0;
+    Date st(2020, 1, 1);
+    Date end(2021, 12, 31);
+
+    Scheduler scheduling(st, end, StepUnit::Month, 2);
+    unsigned n;
+    StepUnit unit;
+    std::tie(n, unit) = scheduling.get_step_length();
+    if (unit != StepUnit::Month || n != 2)
+        num_errors++;
+
+    return num_errors;
+}
+
 int main()
 {
     int num_errors = 0;
@@ -297,7 +390,11 @@ int main()
     num_errors += test_schedule_action_monthly();
     num_errors += test_simulation_step_to_action_step();
     num_errors += test_get_number_of_scheduled_actions();
+    num_errors += test_unit_enum_from_string();
+    num_errors += test_get_step_length();
+    num_errors += test_output_schedule_from_string();
 
+    std::cout << "Test scheduling number of errors: " << num_errors << std::endl;
     return num_errors;
 }
 

--- a/test_treatments.cpp
+++ b/test_treatments.cpp
@@ -407,6 +407,26 @@ int test_clear()
     return num_errors;
 }
 
+int test_treat_app_from_string()
+{
+    int num_errors = 0;
+    if (treatment_app_enum_from_string("ratio_to_all") != TreatmentApplication::Ratio)
+        num_errors++;
+    if (treatment_app_enum_from_string("all_infected_in_cell") != TreatmentApplication::AllInfectedInCell)
+        num_errors++;
+    try {
+        treatment_app_enum_from_string("invalid_input");
+        num_errors++;
+    }
+    catch (std::invalid_argument) {
+        // OK
+    }
+    catch (...) {
+        num_errors++;
+    }
+    return num_errors;
+}
+
 int main()
 {
     int num_errors = 0;
@@ -419,7 +439,9 @@ int main()
     num_errors += test_pesticide_temporal_overlap();
     num_errors += test_steering();
     num_errors += test_clear();
+    num_errors += test_treat_app_from_string();
 
+    std::cout << "Test treatments number of errors: " << num_errors << std::endl;
     return num_errors;
 }
 

--- a/treatments.hpp
+++ b/treatments.hpp
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <vector>
+#include <string>
 #include <functional>
 
 namespace pops {
@@ -35,6 +36,27 @@ enum class TreatmentApplication {
     Ratio,  ///< A ratio is applied to all treated rasters
     AllInfectedInCell  ///< All infected individuals are removed, rest by ratio
 };
+
+/**
+ * @brief Get treatment application enum from string
+
+ * Throws an std::invalid_argument exception if the value
+ * is not supported.
+ */
+inline TreatmentApplication treatment_app_enum_from_string(const std::string& text)
+{
+    std::map<std::string, TreatmentApplication> mapping{
+        {"ratio_to_all", TreatmentApplication::Ratio},
+        {"all_infected_in_cell", TreatmentApplication::AllInfectedInCell}
+    };
+    try {
+        return mapping.at(text);
+    }
+    catch (const std::out_of_range&) {
+        throw std::invalid_argument("treatment_application_enum_from_string:"
+                                    " Invalid value '" + text +"' provided");
+    }
+}
 
 /*!
  * Abstract interface for treatment classes

--- a/treatments.hpp
+++ b/treatments.hpp
@@ -54,7 +54,7 @@ inline TreatmentApplication treatment_app_enum_from_string(const std::string& te
     }
     catch (const std::out_of_range&) {
         throw std::invalid_argument("treatment_application_enum_from_string:"
-                                    " Invalid value '" + text +"' provided");
+                                    " Invalid value '" + text + "' provided");
     }
 }
 

--- a/treatments.hpp
+++ b/treatments.hpp
@@ -47,7 +47,9 @@ inline TreatmentApplication treatment_app_enum_from_string(const std::string& te
 {
     std::map<std::string, TreatmentApplication> mapping{
         {"ratio_to_all", TreatmentApplication::Ratio},
-        {"all_infected_in_cell", TreatmentApplication::AllInfectedInCell}
+        {"ratio", TreatmentApplication::Ratio},
+        {"all_infected_in_cell", TreatmentApplication::AllInfectedInCell},
+        {"all infected", TreatmentApplication::AllInfectedInCell}
     };
     try {
         return mapping.at(text);


### PR DESCRIPTION
Contains helper functions needed for both rpops and r.pops.spread to parse treatment application enum, step unit enum, and function returning output schedule that unifies handling of combinations of simulation step and output step.

Also includes fix for scheduler for cases when given end date of simulation == start date of a last simulation step, now this last simulation step is included in the simulation (e.g. weekly simulation from 1/1 to 1/8 would result in 2 steps - 1/1-1/7 and 1/8-1/14, before this only results in 1/1-1/7).
This is consistent with the previous behavior, if the end date of last interval was after end date of the simulation, the last interval is included.