### PR TITLE
A simple deteministic kernel for tests of simulation

### DIFF
--- a/neighbor_kernel.hpp
+++ b/neighbor_kernel.hpp
@@ -1,7 +1,7 @@
 /*
- * PoPS model - random uniform dispersal kernel
+ * PoPS model - deterministic neighbor dispersal kernel
  *
- * Copyright (C) 2015-2020 by the authors.
+ * Copyright (C) 2020 by the authors.
  *
  * Authors: Vaclav Petras (wenzeslaus gmail com)
  *
@@ -19,15 +19,13 @@
 #include "kernel_types.hpp"
 #include "radial_kernel.hpp"
 
-#include <random>
-
 namespace pops {
 
 /*! Dispersal kernel for deterministic spread to a next cell
  *
  * This kernel spreads only in one direction specified by a parameter.
  * It is useful for testing because the result is completely
- * deteministic.
+ * deterministic.
  *
  * When a diagonal direction such as SE is used, disperser is moved
  * one cell in each cooresponding cardial direction, i.e., 1 S and 1 E
@@ -86,11 +84,11 @@ public:
         return std::make_tuple(row, col);
     }
 
-    /*! \copydoc RadialDispersalKernel::supports_kernel()
+    /*! Enum value is defined, so this always returns false.
      */
     static bool supports_kernel(const DispersalKernelType type)
     {
-        return type == DispersalKernelType::Uniform;
+        return false;
     }
 };
 

--- a/neighbor_kernel.hpp
+++ b/neighbor_kernel.hpp
@@ -23,30 +23,30 @@
 
 namespace pops {
 
-/*! Dispersal kernel for random uniform dispersal over the whole
- * landscape
+/*! Dispersal kernel for deterministic spread to a next cell
  *
- * This class is a good example of how to write a kernel and
- * it is useful for testing due to its simplicity. It tends to generate
- * a lot of spread because it quickly spreads over the landscape.
- * However, it may work as a good starting point for cases where no
- * theory about the spread is available.
+ * This kernel spreads only in one direction specified by a parameter.
+ * It is useful for testing because the result is completely
+ * deteministic.
+ *
+ * When a diagonal direction such as SE is used, disperser is moved
+ * one cell in each cooresponding cardial direction, i.e., 1 S and 1 E
+ * for SE.
  */
-class NeighborDispersalKernel
+class DeterministicNeighborDispersalKernel
 {
 protected:
     Direction direction_;
 public:
-    NeighborDispersalKernel(Direction dispersal_direction)
+    DeterministicNeighborDispersalKernel(Direction dispersal_direction)
         :
           direction_(dispersal_direction)
     {}
 
     /*! \copybrief RadialDispersalKernel::operator()()
      *
-     * The randomness is based on the *generator*.
-     * The new position does not depend on the position of the current
-     * disperser thus *row* and *col* are unused.
+     * Thehere is no randomness, so the *generator*
+     * is unused.
      */
     template<typename Generator>
     std::tuple<int, int> operator() (Generator& generator, int row, int col)

--- a/neighbor_kernel.hpp
+++ b/neighbor_kernel.hpp
@@ -1,0 +1,99 @@
+/*
+ * PoPS model - random uniform dispersal kernel
+ *
+ * Copyright (C) 2015-2020 by the authors.
+ *
+ * Authors: Vaclav Petras (wenzeslaus gmail com)
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef POPS_NEIGHBOR_KERNEL_HPP
+#define POPS_NEIGHBOR_KERNEL_HPP
+
+#include "kernel_types.hpp"
+#include "radial_kernel.hpp"
+
+#include <random>
+
+namespace pops {
+
+/*! Dispersal kernel for random uniform dispersal over the whole
+ * landscape
+ *
+ * This class is a good example of how to write a kernel and
+ * it is useful for testing due to its simplicity. It tends to generate
+ * a lot of spread because it quickly spreads over the landscape.
+ * However, it may work as a good starting point for cases where no
+ * theory about the spread is available.
+ */
+class NeighborDispersalKernel
+{
+protected:
+    Direction direction_;
+public:
+    NeighborDispersalKernel(Direction dispersal_direction)
+        :
+          direction_(dispersal_direction)
+    {}
+
+    /*! \copybrief RadialDispersalKernel::operator()()
+     *
+     * The randomness is based on the *generator*.
+     * The new position does not depend on the position of the current
+     * disperser thus *row* and *col* are unused.
+     */
+    template<typename Generator>
+    std::tuple<int, int> operator() (Generator& generator, int row, int col)
+    {
+        switch (direction_) {
+        case Direction::E:
+            col += 1;
+            break;
+        case Direction::N:
+            row -= 1;
+            break;
+        case Direction::NE:
+            row -= 1;
+            col += 1;
+            break;
+        case Direction::NW:
+            row -= 1;
+            col -= 1;
+            break;
+        case Direction::S:
+            row += 1;
+            break;
+        case Direction::SE:
+            row += 1;
+            col += 1;
+            break;
+        case Direction::SW:
+            row += 1;
+            col -= 1;
+            break;
+        case Direction::W:
+            col -= 1;
+            break;
+        default:
+            throw std::invalid_argument("NeighborDispersalKernel: Unsupported Direction");
+        }
+        return std::make_tuple(row, col);
+    }
+
+    /*! \copydoc RadialDispersalKernel::supports_kernel()
+     */
+    static bool supports_kernel(const DispersalKernelType type)
+    {
+        return type == DispersalKernelType::Uniform;
+    }
+};
+
+} // namespace pops
+
+#endif // POPS_NEIGHBOR_KERNEL_HPP

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -69,7 +69,7 @@ int test_with_neighbor_kernel()
     std::vector<std::tuple<int, int>> outside_dispersers;
     bool weather = false;
     double reproductive_rate = 2;
-    NeighborDispersalKernel kernel(Direction::E);
+    DeterministicNeighborDispersalKernel kernel(Direction::E);
     Simulation<Raster<int>, Raster<double>> simulation(42, infected.rows(), infected.cols());
     dispersers = reproductive_rate * infected;
     // cout << dispersers;

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -64,7 +64,7 @@ int test_with_neighbor_kernel()
     Raster<int> expected_exposed = {{0, 10}, {0, 0}};
     Raster<int> expected_mortality_tracker = expected_exposed;
 
-    Raster<int> exposed(infected.rows(), infected.cols());
+    Raster<int> exposed(infected.rows(), infected.cols(), 0);
     Raster<int> dispersers(infected.rows(), infected.cols());
     std::vector<std::tuple<int, int>> outside_dispersers;
     bool weather = false;
@@ -125,6 +125,7 @@ int test_calling_all_functions()
                         outside_dispersers, weather, weather_coefficient,
                         kernel);
     cout << "outside_dispersers: " << outside_dispersers.size() << endl;
+    return 0;
 }
 
 int main()


### PR DESCRIPTION
Adding a NeighborDispersalKernel which moves disperser one cell in a specified direction. The new test add which is using it can now check exact values in the infected output. The intended use is for testing the steps in SEI. The simulation test was slightly revised.