### PR TITLE
Add operator to assign a single scalar to raster

### DIFF
--- a/raster.hpp
+++ b/raster.hpp
@@ -281,6 +281,13 @@ public:
     }
 
     template<typename OtherNumber>
+    Raster& operator=(OtherNumber value)
+    {
+        this->fill(value);
+        return *this;
+    }
+
+    template<typename OtherNumber>
     Raster& operator+=(OtherNumber value)
     {
         std::for_each(data_, data_ + (cols_ * rows_),


### PR DESCRIPTION
This makes initialization easier when only one value is needed
and it does what contructors are doing.
However, it makes sense only for Raster which won't change
into a scalar (unlike other similar classes), so it can be used
for tests, but not within PoPS itself.
