### PR TITLE
Optionally remove stochasticity in disperser generation and establishment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project should be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2020-05-15 - Reducing stochasticity
+
+### Added
+
+- Stochasticity in Simulation can now be optionally reduced. (Vaclav Petras)
+  * Simulation constructor takes additional parameters to disable
+    stochasticity in generate and disperse functions, particularly in
+    generating and establishing dispersers.
+  * The disperse function takes additional parameter which is a fixed
+    probability value when disperser is established.
+
 ## 2020-04-16 - SEI model
 
 ### Added

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -113,6 +113,8 @@ class Simulation
 private:
     RasterIndex rows_;
     RasterIndex cols_;
+    bool dispersers_stochasticity_;
+    bool establishment_stochasticity_;
     ModelType model_type_;
     unsigned latency_period_;
     std::default_random_engine generator_;
@@ -132,16 +134,22 @@ public:
      * @param random_seed Number to seed the random number generator
      * @param rows Number of rows
      * @param cols Number of columns
+     * @param dispersers_stochasticity Enable stochasticity in generating of dispersers
+     * @param establishment_stochasticity Enable stochasticity in establishment step
      */
     Simulation(unsigned random_seed,
                RasterIndex rows,
                RasterIndex cols,
                ModelType model_type = ModelType::SusceptibleInfected,
-               unsigned latency_period = 0
+               unsigned latency_period = 0,
+               bool dispersers_stochasticity = true,
+               bool establishment_stochasticity = true
                )
         :
           rows_(rows),
           cols_(cols),
+          dispersers_stochasticity_(dispersers_stochasticity),
+          establishment_stochasticity_(establishment_stochasticity),
           model_type_(model_type),
           latency_period_(latency_period)
     {
@@ -291,10 +299,14 @@ public:
                     if (weather)
                         lambda = reproductive_rate * weather_coefficient(i, j); // calculate 
                     int dispersers_from_cell = 0;
-                    std::poisson_distribution<int> distribution(lambda);
-                    
-                    for (int k = 0; k < infected(i, j); k++) {
-                        dispersers_from_cell += distribution(generator_);
+                    if (dispersers_stochasticity_) {
+                        std::poisson_distribution<int> distribution(lambda);
+                        for (int k = 0; k < infected(i, j); k++) {
+                            dispersers_from_cell += distribution(generator_);
+                        }
+                    }
+                    else {
+                        dispersers_from_cell = lambda * infected(i, j);
                     }
                     dispersers(i, j) = dispersers_from_cell;
                 }
@@ -332,6 +344,7 @@ public:
      * @param weather Whether or not weather coefficients should be used
      * @param[in] weather_coefficient Weather coefficient for each location
      * @param dispersal_kernel Dispersal kernel to move dispersers
+     * @param establishment_probability Probability of establishment with no stochasticity
      */
     template<typename DispersalKernel>
     void disperse(const IntegerRaster& dispersers,
@@ -342,7 +355,8 @@ public:
                   std::vector<std::tuple<int, int>>& outside_dispersers,
                   bool weather,
                   const FloatRaster& weather_coefficient,
-                  DispersalKernel& dispersal_kernel)
+                  DispersalKernel& dispersal_kernel,
+                  double establishment_probability = 1)
     {
         std::uniform_real_distribution<double> distribution_uniform(0.0, 1.0);
         int row;
@@ -364,7 +378,9 @@ public:
                             double probability_of_establishment =
                                     (double)(susceptible(row, col)) /
                                     total_plants(row, col);
-                            double establishment_tester = distribution_uniform(generator_);
+                            double establishment_tester = 1 - establishment_probability;
+                            if (establishment_stochasticity_)
+                                establishment_tester = distribution_uniform(generator_);
 
                             if (weather)
                                 probability_of_establishment *= weather_coefficient(i, j);

--- a/simulation.hpp
+++ b/simulation.hpp
@@ -335,6 +335,12 @@ public:
      * on the result, i.e. function returning
      * `std::make_tuple(row, column)` fulfills this requirement.
      *
+     * If establishment stochasticity is disabled,
+     * *establishment_probability* is used to decide whether or not
+     * a disperser is established in a cell. Value 1 means that all
+     * dispresers will establish and value 0 means that no dispersers
+     * will establish.
+     *
      * @param[in] dispersers Dispersing individuals ready to be dispersed
      * @param[in,out] susceptible Susceptible hosts
      * @param[in,out] exposed_or_infected Exposed or infected hosts
@@ -356,7 +362,7 @@ public:
                   bool weather,
                   const FloatRaster& weather_coefficient,
                   DispersalKernel& dispersal_kernel,
-                  double establishment_probability = 1)
+                  double establishment_probability = 0.5)
     {
         std::uniform_real_distribution<double> distribution_uniform(0.0, 1.0);
         int row;

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -134,6 +134,7 @@ int test_with_reduced_stochasticity()
     double reproductive_rate = 2;
     bool generate_stochasticity = false;
     bool establishment_stochasticity = false;
+    // We want everything to establish.
     double establishment_probability = 1;
     DeterministicNeighborDispersalKernel kernel(Direction::E);
     Simulation<Raster<int>, Raster<double>> simulation(

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -116,6 +116,60 @@ int test_with_neighbor_kernel()
     return 0;
 }
 
+int test_with_reduced_stochasticity()
+{
+    Raster<int> infected = {{5, 0}, {0, 0}};
+    Raster<int> mortality_tracker = {{0, 0}, {0, 0}};
+    Raster<int> susceptible = {{10, 20}, {14, 15}};
+    Raster<int> total_plants = susceptible;
+    Raster<double> temperature = {{5, 0}, {0, 0}};
+    Raster<double> weather_coefficient = {{0, 0}, {0, 0}};
+
+    Raster<int> expected_mortality_tracker = {{0, 10}, {0, 0}};
+    auto expected_infected = expected_mortality_tracker + infected;
+
+    Raster<int> dispersers(infected.rows(), infected.cols());
+    std::vector<std::tuple<int, int>> outside_dispersers;
+    bool weather = false;
+    double reproductive_rate = 2;
+    bool generate_stochasticity = false;
+    bool establishment_stochasticity = false;
+    double establishment_probability = 1;
+    DeterministicNeighborDispersalKernel kernel(Direction::E);
+    Simulation<Raster<int>, Raster<double>> simulation(
+                42,
+                infected.rows(),
+                infected.cols(),
+                model_type_from_string("SI"),
+                0,
+                generate_stochasticity,
+                establishment_stochasticity
+                );
+    simulation.generate(dispersers, infected, weather, weather_coefficient, reproductive_rate);
+    auto expected_dispersers = reproductive_rate * infected;
+    if (dispersers != expected_dispersers) {
+        cout << "reduced_stochasticity: dispersers (actual, expected):\n" << dispersers << "  !=\n" << expected_dispersers << "\n";
+        return 1;
+    }
+    simulation.disperse(dispersers, susceptible, infected,
+                        mortality_tracker, total_plants,
+                        outside_dispersers, weather, weather_coefficient,
+                        kernel, establishment_probability);
+    if (!outside_dispersers.empty()) {
+        cout << "reduced_stochasticity: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be none\n";
+        return 1;
+    }
+    if (infected != expected_infected) {
+        cout << "reduced_stochasticity: infected (actual, expected):\n" << infected << "  !=\n" << expected_infected << "\n";
+        return 1;
+    }
+    if (mortality_tracker != expected_mortality_tracker) {
+        cout << "reduced_stochasticity: mortality tracker (actual, expected):\n" << mortality_tracker << "  !=\n" << expected_mortality_tracker << "\n";
+        return 1;
+    }
+    return 0;
+}
+
 int disperse_and_infect_postcondition(int step, const std::vector<Raster<int>>& exposed)
 {
     Raster<int> zeros(exposed[0].rows(), exposed[0].cols(), 0);
@@ -186,6 +240,7 @@ int test_with_sei()
                 42,
                 infected.rows(),
                 infected.cols(),
+
                 model_type_from_string("SEI"),
                 latency_period_steps
                 );
@@ -449,6 +504,7 @@ int main()
 
     ret += test_calling_all_functions();
     ret += test_with_neighbor_kernel();
+    ret += test_with_reduced_stochasticity();
     ret += test_with_sei();
     ret += test_SI_versus_SEI0();
 


### PR DESCRIPTION
Stochasticity can be now reduced by turning it off in generate function and in the
establishment step of the disperse function.
