### PR TITLE
Created new deterministic dispersal kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXXFLAGS := $(CXXFLAGS) -std=c++11 -pedantic -Wall -Wextra
 COMMON_DEFINES := -D POPS_TEST
 
-all: test_date test_raster test_simulation test_treatments test_spread_rate test_statistics test_scheduling
+all: test_date test_raster test_simulation test_treatments test_spread_rate test_statistics test_scheduling test_deterministic
 
 test_date: test_date.cpp date.hpp
 	g++ $(CXXFLAGS) $(COMMON_DEFINES) test_date.cpp -o test_date
@@ -23,6 +23,10 @@ test_statistics: test_statistics.cpp *.hpp
 
 test_scheduling: test_scheduling.cpp *.hpp
 	g++ $(CXXFLAGS) $(COMMON_DEFINES) test_scheduling.cpp -o test_scheduling
+
+test_deterministic: test_deterministic.cpp *.hpp
+	g++ $(CXXFLAGS) $(COMMON_DEFINES) test_deterministic.cpp -o test_deterministic
+
 test:
 	./test_date
 	./test_raster
@@ -31,6 +35,7 @@ test:
 	./test_spread_rate
 	./test_statistics
 	./test_scheduling
+	./test_deterministic
 
 doc:
 	doxygen
@@ -43,3 +48,4 @@ clean:
 	rm -f test_spread_rate
 	rm -f test_statistics
 	rm -f test_scheduling
+	rm -f test_deterministic

--- a/deterministic_kernel.hpp
+++ b/deterministic_kernel.hpp
@@ -1,0 +1,225 @@
+/*
+ * PoPS model - deterministic dispersal kernel
+ *
+ * Copyright (C) 2015-2020 by the authors.
+ *
+ * Authors: Margaret Lawrimore (malawrim ncsu edu)
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef POPS_DETERMINISTIC_KERNEL_HPP
+#define POPS_DETERMINISTIC_KERNEL_HPP
+
+#include "kernel_types.hpp"
+#include "radial_kernel.hpp"
+
+#include <vector>
+#include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+#ifndef PI
+#define PI M_PI
+#endif
+
+namespace pops {
+
+/*! 
+ * Cauchy probability density function
+ * returns the probability that the variate has the value x
+ */
+class cauchy_density_function
+{
+public:
+	cauchy_density_function(double scale, double locator)
+        : s(scale), t(locator)
+    {}
+
+    double operator ()(double x)
+    {
+    	return 1 / ((s*PI)*(1 + (std::pow((x - t)/s, 2))));
+    
+    }
+private:
+	// scale parameter - specifies half width at half maximum - 1 for standard
+	// often referred to as lamba which equals 1/beta
+    double s;
+    // location parameter - location of peak - 0 for standard
+    double t;
+};
+
+// 
+/*! 
+ * Exponential probability density function 
+ * returns the probability that the variate has the value x
+ */
+class exponential_density_function
+{
+public:
+exponential_density_function(double scale, double locator)
+        : beta(scale), mu(locator)
+    {}
+    
+    double operator ()(double x)
+    {
+    	return (1/beta)*(std::exp(-(x-mu)/beta));
+    }
+private:
+	// scale parameter - 1 for standard
+	double beta;
+	// location parameter - 0 for standard 
+    double mu;
+};
+/*! 
+ * Dispersal kernel for deterministic spread to cell with highest probability of spread
+ *
+ * Given a boundaries of the raster, to avoid spreading beyond boundaries of raster
+ * Dispersal Kernel type determines use of Exponential or Cauchy distribution
+ * to determine probability.
+ *
+ * Useful for testing as it is deterministic and provides
+ * fully replicable results 
+ */
+class DeterministicDispersalKernel
+{
+protected:
+    int row_max_;
+    int col_max_;
+    Raster<int> dispersers_;
+    DispersalKernelType kernel_type_;
+    
+    int prev_row = -1;
+    int prev_col = -1;
+    int window_r_min;
+    int window_r_max;
+    int window_c_min;
+    int window_c_max;
+    std::vector<std::vector<double>> probability;
+    std::vector<std::vector<double>> window;
+    cauchy_density_function cauchy_pdf;
+    exponential_density_function exponential_pdf;
+public:
+    DeterministicDispersalKernel(int row_max, int col_max, DispersalKernelType dispersal_kernel,
+                          		double distance_scale, double locator, Raster<int> dispersers)
+        :
+        row_max_(row_max),
+        col_max_(col_max),
+        dispersers_(dispersers),
+        cauchy_pdf(distance_scale, locator),
+        exponential_pdf(distance_scale, locator),
+        kernel_type_(dispersal_kernel)
+    {
+    	// create probability matrix
+    	// compute distance from center to all cells
+    	probability.resize(row_max, std::vector<double>(col_max));
+    	int med_row = row_max_/2;
+    	int med_col = col_max_/2;
+    	double sum = 0;
+    	for ( int i = 0; i < row_max_; i++ ) {
+    		for ( int j = 0; j < col_max_; j++ ) {
+    			// store distance to center
+    			probability[i][j] = std::abs(med_row - i) + std::abs(med_col - j);
+    			// determine probability based on distance
+    			if (kernel_type_ == DispersalKernelType::Cauchy) {
+ 					probability[i][j] = std::abs(cauchy_pdf(probability[i][j]));
+ 				} else if ( kernel_type_ == DispersalKernelType::Exponential ) {
+ 					probability[i][j] = std::abs(exponential_pdf(probability[i][j]));
+ 				}
+ 				sum += probability[i][j];
+    		}
+    	}
+    	//normalize based on the sum of all probabilities in the raster
+    	for ( int i = 0; i < row_max_; i++ ) {
+    		for ( int j = 0; j < col_max_; j++ ) {
+    			probability[i][j] /= sum;
+    		}
+    	}
+    }
+
+    /*! Generates a new position for the spread.
+     *
+     *  Creates smaller matrix "window" from probability matrix
+     *  New window created any time a new cell is selected from simulation.disperse
+     *
+     *  Selects next row/col value based on the cell with the highest probability
+     *  in the window.
+     *
+     *  Generator is not used
+     */
+    template<typename Generator>
+    std::tuple<int, int> operator() (Generator& generator, int row, int col)
+    {
+
+		// reset the window if considering a new cell
+    	if ( row != prev_row || col != prev_col ) {
+    		int dispersers_num = dispersers_(row, col)/2;
+    		
+    		// determine moving window boundary values
+    		// length/width = number of dispersers
+    		// TODO could change to different dimensions
+    		window_r_min = ((row - (dispersers_num)) < 0) ? 0 : (row - (dispersers_num));
+    		window_r_max = ((row + (dispersers_num)) > row_max_) ? row_max_ : (row + (dispersers_num));
+			window_c_min = ((col - (dispersers_num)) < 0 ) ? 0 : (col - (dispersers_num));
+    		window_c_max = ((col + (dispersers_num)) > col_max_) ? col_max_ : (col + (dispersers_num));
+    		window.resize((window_r_max - window_r_min), std::vector<double>(window_c_max - window_c_min));
+    		// copy probabilities from window_r_max matrix
+    		for ( int i = window_r_min; i < window_r_max; i++) {
+    			for ( int j = window_c_min; j < window_c_max; j++) {
+    				window[i][j] = probability[i][j];
+    			}
+    		}
+    	}
+    	
+    	double max = (double)-std::numeric_limits<int>::max();
+    	// have to add a max value because if row == window_r_min and the probability
+    	// of this cell is greater than every other cell - no cell will be selected
+    	int max_prob_row = window_r_min;
+    	int max_prob_col = window_c_min;
+    	
+    	//find cell with highest probability
+    	for ( int i = window_r_min; i < window_r_max; i++ ) {
+    		for ( int j = window_c_min; j < window_c_max; j++ ) {
+    			if (i == row && j == col) {
+    				// do nothing
+    			}
+    			else if (window[i][j] > max ) {
+    				max = window[i][j];
+    				max_prob_row = i;
+					max_prob_col = j;
+    			}
+    		}
+    	}
+
+		// subtracting 1 preserves the probability order but ensures that this cell
+		// is not select again unless all other cells in window have been selected
+    	window[max_prob_row][max_prob_col] -= 1;
+    	
+    	prev_row = row;
+    	prev_col = col;
+        return std::make_tuple(max_prob_row, max_prob_col);
+    }
+
+    /*! \copydoc RadialDispersalKernel::supports_kernel()
+     */
+     // copied from radial_kernel
+    static bool supports_kernel(const DispersalKernelType type)
+    {
+        static const std::array<DispersalKernelType, 2> supports = {
+            DispersalKernelType::Cauchy,
+            DispersalKernelType::Exponential
+        };
+        auto it = std::find(supports.cbegin(), supports.cend(), type);
+        return it != supports.cend();;
+    }
+};
+
+} // namespace pops
+
+#endif // POPS_DETERMINISTIC_KERNEL_HPP

--- a/deterministic_kernel.hpp
+++ b/deterministic_kernel.hpp
@@ -17,7 +17,6 @@
 #define POPS_DETERMINISTIC_KERNEL_HPP
 
 #include <vector>
-#include <cmath>
 #include <tuple>
 
 #include "raster.hpp"
@@ -33,7 +32,6 @@ namespace pops {
 
 using std::pow;
 using std::tan;
-using std::atan;
 using std::exp;
 using std::log;
 using std::ceil;

--- a/radial_kernel.hpp
+++ b/radial_kernel.hpp
@@ -165,6 +165,7 @@ Direction direction_from_string(const char* text)
  * its implementation in the function call operator, and extend the
  * supports_kernel() function.
  */
+template<typename IntegerRaster>
 class RadialDispersalKernel
 {
 protected:
@@ -176,7 +177,7 @@ protected:
     std::cauchy_distribution<double> cauchy_distribution;
     std::exponential_distribution<double> exponential_distribution;
     von_mises_distribution von_mises;
-    DeterministicDispersalKernel deterministic_kernel;
+    DeterministicDispersalKernel<IntegerRaster> deterministic_kernel;
     bool deterministic_;
 public:
     RadialDispersalKernel(double ew_res, double ns_res,
@@ -185,7 +186,7 @@ public:
                           Direction dispersal_direction = Direction::None,
                           double dispersal_direction_kappa = 0,
                           bool deterministic = false,
-                          Raster<int> dispersers = {{0}},
+                          IntegerRaster dispersers = {{0}},
                           double dispersal_percentage = 0.99,
                           double locator = 0.0
             )
@@ -219,9 +220,9 @@ public:
     template<typename Generator>
     std::tuple<int, int> operator() (Generator& generator, int row, int col)
     {
-    	if (deterministic_) {
-    		return deterministic_kernel.spread(row, col);
-    	}
+        if (deterministic_) {
+            return deterministic_kernel(generator, row, col);
+        }
         double distance = 0;
         double theta = 0;
         // switch between the supported kernels

--- a/radial_kernel.hpp
+++ b/radial_kernel.hpp
@@ -182,13 +182,12 @@ protected:
 public:
     RadialDispersalKernel(double ew_res, double ns_res,
                           DispersalKernelType dispersal_kernel,
-                          double distance_scale = 1.0,
+                          double distance_scale,
                           Direction dispersal_direction = Direction::None,
                           double dispersal_direction_kappa = 0,
                           bool deterministic = false,
                           const IntegerRaster& dispersers = {{0}},
-                          double dispersal_percentage = 0.99,
-                          double locator = 0.0
+                          double dispersal_percentage = 0.99
             )
         :
           east_west_resolution(ew_res),
@@ -201,7 +200,7 @@ public:
           // so we do multiplicative inverse to behave like cauchy.
           exponential_distribution(1.0 / distance_scale),
           deterministic_(deterministic),
-          deterministic_kernel(dispersal_kernel, dispersers, dispersal_percentage, ew_res, ns_res, distance_scale, locator),
+          deterministic_kernel(dispersal_kernel, dispersers, dispersal_percentage, ew_res, ns_res, distance_scale),
           // if no wind, then kappa is 0
           // TODO: change these two computations to standalone inline
           // functions (dir to rad and adjust kappa)

--- a/radial_kernel.hpp
+++ b/radial_kernel.hpp
@@ -186,7 +186,7 @@ public:
                           Direction dispersal_direction = Direction::None,
                           double dispersal_direction_kappa = 0,
                           bool deterministic = false,
-                          IntegerRaster dispersers = {{0}},
+                          const IntegerRaster& dispersers = {{0}},
                           double dispersal_percentage = 0.99,
                           double locator = 0.0
             )

--- a/test_deterministic.cpp
+++ b/test_deterministic.cpp
@@ -79,7 +79,7 @@ int test_with_cauchy_deterministic_kernel()
         cout << "Deterministic Kernel Cauchy: dispersers (actual, expected):\n" << dispersers << "  !=\n" << expected_dispersers << "\n";
         return 1;
     }
-    RadialDispersalKernel<Raster<int>> deterministicKernel(30, 30, DispersalKernelType::Cauchy, 0.3, Direction::None, 0.0, true, dispersers, 0.99, 0.0);
+    RadialDispersalKernel<Raster<int>> deterministicKernel(30, 30, DispersalKernelType::Cauchy, 0.9, Direction::None, 0.0, true, dispersers, 0.9, 0.0);
     // using a smaller scale value since the test raster is so small
     simulation.disperse(dispersers, susceptible, infected,
                         mortality_tracker, total_hosts,
@@ -140,12 +140,12 @@ int test_with_exponential_deterministic_kernel()
         cout << "Deterministic Kernel Exponential: dispersers (actual, expected):\n" << dispersers << "  !=\n" << expected_dispersers << "\n";
         return 1;
     }
-    RadialDispersalKernel<Raster<int>> deterministicKernel2(30, 30, DispersalKernelType::Exponential, 1.0, Direction::None, 0.0, true, dispersers, 0.99, 0.0);
+    RadialDispersalKernel<Raster<int>> deterministicKernel(30, 30, DispersalKernelType::Exponential, 1.0, Direction::None, 0.0, true, dispersers, 0.99, 0.0);
 
     s2.disperse(dispersers, susceptible, infected,
                         mortality_tracker, total_hosts,
                         outside_dispersers, weather, weather_coefficient,
-                        deterministicKernel2, establishment_probability);
+                        deterministicKernel, establishment_probability);
     if (outside_dispersers.size() != 0) {
         cout << "Deterministic Kernel Exponential: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be 0\n";
         return 1;
@@ -164,7 +164,7 @@ int test_with_exponential_deterministic_kernel()
 
 int test_cauchy_distribution_functions()
 {
-    // testing cauchy pdf & cdf
+    // testing cauchy pdf & icdf
     double scale = 0.001;  // rounding to thousands place
     CauchyDistribution cauchy(1.0, 0.0);
     double probability = (int) (cauchy.pdf(5) / scale) * scale;
@@ -173,8 +173,8 @@ int test_cauchy_distribution_functions()
         cout << "Cauchy Distribution: probability was " << probability << " but should be " << probability_ref << "\n";
         return 1;
     }
-    double x = (int) (cauchy.cdf(0.98) / scale) * scale;
-    double x_ref = 63.641;
+    double x = (int) (cauchy.icdf(0.98) / scale) * scale;
+    double x_ref = 15.894;
     if ( x != x_ref) {
         cout << "Cauchy Distribution: x was " << x << " but should be " << x_ref << "\n";
         return 1;
@@ -186,20 +186,20 @@ int test_cauchy_distribution_functions()
         cout << "Cauchy Distribution: probability was " << probability << " but should be " << probability_ref << "\n";
         return 1;
     }
-    x = (int) (cauchy1.cdf(0.98) / scale) * scale;
-    x_ref = 9.138;
+    x = (int) (cauchy1.icdf(0.98) / scale) * scale;
+    x_ref = 24.341;
     if ( x != x_ref) {
         cout << "Cauchy Distribution: x was " << x << " but should be " << x_ref << "\n";
         return 1;
     }
-    cout << "Cauchy Distribution: cdf and pdf pass\n";
+    cout << "Cauchy Distribution: icdf and pdf pass\n";
     return 0;
 }
 
 int test_exponential_distribution_functions()
 {
     double scale = 0.001;  // rounding to thousands place
-    // testing exponential pdf & cdf
+    // testing exponential pdf & icdf
     ExponentialDistribution exponential(1.0);
     double probability = (int) (exponential.pdf(1) / scale) * scale;
     double probability_ref = 0.367;
@@ -207,7 +207,7 @@ int test_exponential_distribution_functions()
         cout << "Exponential Distribution: probability was " << probability << " but should be " << probability_ref << "\n";
         return 1;
     }
-    double x = (int) (exponential.cdf(0.98) / scale) * scale;
+    double x = (int) (exponential.icdf(0.98) / scale) * scale;
     double x_ref = 3.912;
     if ( x != x_ref) {
         cout << "Exponential Distribution: x was " << x << " but should be " << x_ref << "\n";
@@ -220,13 +220,13 @@ int test_exponential_distribution_functions()
         cout << "Exponential Distribution: probability was " << probability << " but should be " << probability_ref << "\n";
         return 1;
     }
-    x = (int) (exponential2.cdf(0.98) / scale) * scale;
+    x = (int) (exponential2.icdf(0.98) / scale) * scale;
     x_ref = 5.868;
     if ( x != x_ref) {
         cout << "Exponential Distribution: x was " << x << " but should be " << x_ref << "\n";
         return 1;
     }
-    cout << "Exponential Distribution: cdf and pdf pass\n";
+    cout << "Exponential Distribution: icdf and pdf pass\n";
     return 0;
 }
 

--- a/test_deterministic.cpp
+++ b/test_deterministic.cpp
@@ -1,0 +1,244 @@
+#ifdef POPS_TEST
+
+/*
+ * Simple compilation test for the PoPS deterministic_kernel class.
+ *
+ * Copyright (C) 2018-2020 by the authors.
+ *
+ * Authors: Margaret Lawrimore <malawrim ncsu edu>
+ *
+ * This file is part of PoPS.
+
+ * PoPS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+
+ * PoPS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with PoPS. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "raster.hpp"
+#include "radial_kernel.hpp"
+#include "simulation.hpp"
+#include "deterministic_kernel.hpp"
+
+#include <map>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+using std::string;
+using std::cout;
+
+using namespace pops;
+
+int test_with_cauchy_deterministic_kernel()
+{
+    Raster<int> infected = {{5, 0, 0}, {0, 5, 0}, {0, 0, 2}};
+    Raster<int> mortality_tracker = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
+    Raster<int> susceptible = {{10, 20, 9}, {14, 15, 0}, {3, 0, 2}};
+    Raster<int> total_hosts = susceptible;
+    Raster<double> temperature = {{5, 0, 0}, {0, 0, 0}, {0, 0, 2}};
+    Raster<double> weather_coefficient = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
+    std::vector<std::vector<int>> movements = {{0, 0, 1, 1, 2}, {0, 1, 0, 0, 3}, {0, 1, 1, 0, 2}};
+    std::vector<unsigned> movement_schedule = {1, 1};
+
+    Raster<int> expected_mortality_tracker = {{10, 0, 0}, {0, 10, 0}, {0, 0, 2}};
+    Raster<int> expected_infected = {{15, 0, 0}, {0, 15, 0}, {0, 0, 4}};
+
+    Raster<int> dispersers(infected.rows(), infected.cols());
+    std::vector<std::tuple<int, int>> outside_dispersers;
+    bool weather = false;
+    double reproductive_rate = 2;
+    bool generate_stochasticity = false;
+    bool establishment_stochasticity = false;
+    // We want everything to establish.
+    double establishment_probability = 1;
+    // Cauchy
+    Simulation<Raster<int>, Raster<double>> simulation(
+                42,
+                infected.rows(),
+                infected.cols(),
+                model_type_from_string("SI"),
+                0,
+                generate_stochasticity,
+                establishment_stochasticity
+                );
+    simulation.generate(dispersers, infected, weather, weather_coefficient, reproductive_rate);
+    auto expected_dispersers = reproductive_rate * infected;
+    if (dispersers != expected_dispersers) {
+        cout << "Deterministic Kernel Cauchy: dispersers (actual, expected):\n" << dispersers << "  !=\n" << expected_dispersers << "\n";
+        return 1;
+    }
+    RadialDispersalKernel<Raster<int>> deterministicKernel(30, 30, DispersalKernelType::Cauchy, 0.3, Direction::None, 0.0, true, dispersers, 0.99, 0.0);
+    // using a smaller scale value since the test raster is so small
+    simulation.disperse(dispersers, susceptible, infected,
+                        mortality_tracker, total_hosts,
+                        outside_dispersers, weather, weather_coefficient,
+                        deterministicKernel, establishment_probability);
+    if (outside_dispersers.size() != 0) {
+        cout << "Deterministic Kernel Cauchy: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be 0\n";
+        return 1;
+    }
+    if (infected != expected_infected) {
+        cout << "Deterministic Kernel Cauchy: infected (actual, expected):\n" << infected << "  !=\n" << expected_infected << "\n";
+        return 1;
+    }
+    if (mortality_tracker != expected_mortality_tracker) {
+        cout << "Deterministic Kernel Cauchy: mortality tracker (actual, expected):\n" << mortality_tracker << "  !=\n" << expected_mortality_tracker << "\n";
+        return 1;
+    }
+    cout << "Deterministic Kernel Cauchy: no errors\n";
+    return 0;
+}
+
+int test_with_exponential_deterministic_kernel()
+{
+    Raster<int> infected = {{5, 0, 0}, {0, 5, 0}, {0, 0, 2}};
+    Raster<int> mortality_tracker = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
+    Raster<int> susceptible = {{10, 20, 9}, {14, 15, 0}, {3, 0, 2}};
+    Raster<int> total_hosts = susceptible;
+    Raster<double> movements = {{0, 0, 1, 1, 2}, {0, 1, 0, 0, 3}, {0, 1, 1, 0, 2}};
+    Raster<double> temperature = {{5, 0, 0}, {0, 0, 0}, {0, 0, 2}};
+    Raster<double> weather_coefficient = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
+    std::vector<unsigned> movement_schedule = {1, 1};
+
+    Raster<int> expected_mortality_tracker = {{10, 0, 0}, {0, 10, 0}, {0, 0, 2}};
+    Raster<int> expected_infected = {{15, 0, 0}, {0, 15, 0}, {0, 0, 4}};
+
+    Raster<int> dispersers(infected.rows(), infected.cols());
+    std::vector<std::tuple<int, int>> outside_dispersers;
+
+    bool weather = false;
+    double reproductive_rate = 2;
+    bool generate_stochasticity = false;
+    bool establishment_stochasticity = false;
+    // We want everything to establish.
+    double establishment_probability = 1;
+    // Exponential
+    Simulation<Raster<int>, Raster<double>> s2(
+                42,
+                infected.rows(),
+                infected.cols(),
+                model_type_from_string("SI"),
+                0,
+                generate_stochasticity,
+                establishment_stochasticity
+                );
+    s2.generate(dispersers, infected, weather, weather_coefficient, reproductive_rate);
+    auto expected_dispersers = reproductive_rate * infected;
+    if (dispersers != expected_dispersers) {
+        cout << "Deterministic Kernel Exponential: dispersers (actual, expected):\n" << dispersers << "  !=\n" << expected_dispersers << "\n";
+        return 1;
+    }
+    RadialDispersalKernel<Raster<int>> deterministicKernel2(30, 30, DispersalKernelType::Exponential, 1.0, Direction::None, 0.0, true, dispersers, 0.99, 0.0);
+
+    s2.disperse(dispersers, susceptible, infected,
+                        mortality_tracker, total_hosts,
+                        outside_dispersers, weather, weather_coefficient,
+                        deterministicKernel2, establishment_probability);
+    if (outside_dispersers.size() != 0) {
+        cout << "Deterministic Kernel Exponential: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be 0\n";
+        return 1;
+    }
+    if (infected != expected_infected) {
+        cout << "Deterministic Kernel Exponential: infected (actual, expected):\n" << infected << "  !=\n" << expected_infected << "\n";
+        return 1;
+    }
+    if (mortality_tracker != expected_mortality_tracker) {
+        cout << "Deterministic Kernel Exponential: mortality tracker (actual, expected):\n" << mortality_tracker << "  !=\n" << expected_mortality_tracker << "\n";
+        return 1;
+    }
+    cout << "Deterministic Kernel Exponential: no errors\n";
+    return 0;
+}
+
+int test_cauchy_distribution_functions()
+{
+    // testing cauchy pdf & cdf
+    double scale = 0.001;  // rounding to thousands place
+    CauchyDistribution cauchy(1.0, 0.0);
+    double probability = (int) (cauchy.pdf(5) / scale) * scale;
+    double probability_ref = 0.012;
+    if ( probability != probability_ref) {
+        cout << "Cauchy Distribution: probability was " << probability << " but should be " << probability_ref << "\n";
+        return 1;
+    }
+    double x = (int) (cauchy.cdf(0.98) / scale) * scale;
+    double x_ref = 63.641;
+    if ( x != x_ref) {
+        cout << "Cauchy Distribution: x was " << x << " but should be " << x_ref << "\n";
+        return 1;
+    }
+    CauchyDistribution cauchy1(1.5, 0.5);
+    probability_ref = 0.021;
+    probability = (int) (cauchy1.pdf(5) / scale) * scale;
+    if ( probability != probability_ref) {
+        cout << "Cauchy Distribution: probability was " << probability << " but should be " << probability_ref << "\n";
+        return 1;
+    }
+    x = (int) (cauchy1.cdf(0.98) / scale) * scale;
+    x_ref = 9.138;
+    if ( x != x_ref) {
+        cout << "Cauchy Distribution: x was " << x << " but should be " << x_ref << "\n";
+        return 1;
+    }
+    cout << "Cauchy Distribution: cdf and pdf pass\n";
+    return 0;
+}
+
+int test_exponential_distribution_functions()
+{
+    double scale = 0.001;  // rounding to thousands place
+    // testing exponential pdf & cdf
+    ExponentialDistribution exponential(1.0);
+    double probability = (int) (exponential.pdf(1) / scale) * scale;
+    double probability_ref = 0.367;
+    if ( probability != probability_ref) {
+        cout << "Exponential Distribution: probability was " << probability << " but should be " << probability_ref << "\n";
+        return 1;
+    }
+    double x = (int) (exponential.cdf(0.98) / scale) * scale;
+    double x_ref = 3.912;
+    if ( x != x_ref) {
+        cout << "Exponential Distribution: x was " << x << " but should be " << x_ref << "\n";
+        return 1;
+    }
+    ExponentialDistribution exponential2(1.5);
+    probability = (int) (exponential2.pdf(1) / scale) * scale;
+    probability_ref = 0.342;
+    if ( probability != probability_ref) {
+        cout << "Exponential Distribution: probability was " << probability << " but should be " << probability_ref << "\n";
+        return 1;
+    }
+    x = (int) (exponential2.cdf(0.98) / scale) * scale;
+    x_ref = 5.868;
+    if ( x != x_ref) {
+        cout << "Exponential Distribution: x was " << x << " but should be " << x_ref << "\n";
+        return 1;
+    }
+    cout << "Exponential Distribution: cdf and pdf pass\n";
+    return 0;
+}
+
+int main()
+{
+    int ret = 0;
+
+    ret += test_with_exponential_deterministic_kernel();
+    ret += test_with_cauchy_deterministic_kernel();
+    ret += test_cauchy_distribution_functions();
+    ret += test_exponential_distribution_functions();
+
+    return ret;
+}
+#endif  // POPS_TEST

--- a/test_deterministic.cpp
+++ b/test_deterministic.cpp
@@ -69,7 +69,7 @@ int test_with_cauchy_deterministic_kernel()
         cout << "Deterministic Kernel Cauchy: dispersers (actual, expected):\n" << dispersers << "  !=\n" << expected_dispersers << "\n";
         return 1;
     }
-    RadialDispersalKernel<Raster<int>> deterministicKernel(30, 30, DispersalKernelType::Cauchy, 0.9, Direction::None, 0.0, true, dispersers, 0.9, 0.0);
+    RadialDispersalKernel<Raster<int>> deterministicKernel(30, 30, DispersalKernelType::Cauchy, 0.9, Direction::None, 0.0, true, dispersers, 0.9);
     // using a smaller scale value since the test raster is so small
     simulation.disperse(dispersers, susceptible, infected,
                         mortality_tracker, total_hosts,
@@ -129,7 +129,7 @@ int test_with_exponential_deterministic_kernel()
         cout << "Deterministic Kernel Exponential: dispersers (actual, expected):\n" << dispersers << "  !=\n" << expected_dispersers << "\n";
         return 1;
     }
-    RadialDispersalKernel<Raster<int>> deterministicKernel(30, 30, DispersalKernelType::Exponential, 1.0, Direction::None, 0.0, true, dispersers, 0.99, 0.0);
+    RadialDispersalKernel<Raster<int>> deterministicKernel(30, 30, DispersalKernelType::Exponential, 1.0, Direction::None, 0.0, true, dispersers, 0.99);
 
     s2.disperse(dispersers, susceptible, infected,
                         mortality_tracker, total_hosts,
@@ -154,7 +154,7 @@ int test_cauchy_distribution_functions()
 {
     // testing cauchy pdf & icdf
     double scale = 0.001;  // rounding to thousands place
-    CauchyDistribution cauchy(1.0, 0.0);
+    CauchyDistribution cauchy(1.0);
     double probability = (int) (cauchy.pdf(5) / scale) * scale;
     double probability_ref = 0.012;
     if ( probability != probability_ref) {
@@ -167,15 +167,15 @@ int test_cauchy_distribution_functions()
         cout << "Cauchy Distribution: x was " << x << " but should be " << x_ref << "\n";
         return 1;
     }
-    CauchyDistribution cauchy1(1.5, 0.5);
-    probability_ref = 0.021;
+    CauchyDistribution cauchy1(1.5);
+    probability_ref = 0.017;
     probability = (int) (cauchy1.pdf(5) / scale) * scale;
     if ( probability != probability_ref) {
         cout << "Cauchy Distribution: probability was " << probability << " but should be " << probability_ref << "\n";
         return 1;
     }
     x = (int) (cauchy1.icdf(0.98) / scale) * scale;
-    x_ref = 24.341;
+    x_ref = 23.841;
     if ( x != x_ref) {
         cout << "Cauchy Distribution: x was " << x << " but should be " << x_ref << "\n";
         return 1;

--- a/test_deterministic.cpp
+++ b/test_deterministic.cpp
@@ -23,18 +23,8 @@
  * along with PoPS. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "raster.hpp"
 #include "radial_kernel.hpp"
 #include "simulation.hpp"
-#include "deterministic_kernel.hpp"
-
-#include <map>
-#include <iostream>
-#include <memory>
-#include <stdexcept>
-#include <fstream>
-#include <sstream>
-#include <string>
 
 using std::string;
 using std::cout;
@@ -97,7 +87,6 @@ int test_with_cauchy_deterministic_kernel()
         cout << "Deterministic Kernel Cauchy: mortality tracker (actual, expected):\n" << mortality_tracker << "  !=\n" << expected_mortality_tracker << "\n";
         return 1;
     }
-    cout << "Deterministic Kernel Cauchy: no errors\n";
     return 0;
 }
 
@@ -158,7 +147,6 @@ int test_with_exponential_deterministic_kernel()
         cout << "Deterministic Kernel Exponential: mortality tracker (actual, expected):\n" << mortality_tracker << "  !=\n" << expected_mortality_tracker << "\n";
         return 1;
     }
-    cout << "Deterministic Kernel Exponential: no errors\n";
     return 0;
 }
 
@@ -192,7 +180,6 @@ int test_cauchy_distribution_functions()
         cout << "Cauchy Distribution: x was " << x << " but should be " << x_ref << "\n";
         return 1;
     }
-    cout << "Cauchy Distribution: icdf and pdf pass\n";
     return 0;
 }
 
@@ -226,7 +213,6 @@ int test_exponential_distribution_functions()
         cout << "Exponential Distribution: x was " << x << " but should be " << x_ref << "\n";
         return 1;
     }
-    cout << "Exponential Distribution: icdf and pdf pass\n";
     return 0;
 }
 
@@ -239,6 +225,7 @@ int main()
     ret += test_cauchy_distribution_functions();
     ret += test_exponential_distribution_functions();
 
+    std::cout << "Test deterministic number of errors: " << ret << std::endl;
     return ret;
 }
 #endif  // POPS_TEST

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -183,8 +183,8 @@ int test_with_deterministic_kernel()
     std::vector<std::vector<int>> movements = {{0, 0, 1, 1, 2}, {0, 1, 0, 0, 3}, {0, 1, 1, 0, 2}};
     std::vector<unsigned> movement_schedule = {1, 1};
 
-    Raster<int> expected_mortality_tracker = {{1, 3, 1}, {3, 1, 0}, {1, 0, 1}};
-    Raster<int> expected_infected = {{6, 3, 1}, {3, 6, 0}, {1, 0, 3}};
+    Raster<int> expected_mortality_tracker = {{10, 0, 0}, {0, 10, 0}, {0, 0, 2}};
+    Raster<int> expected_infected = {{15, 0, 0}, {0, 15, 0}, {0, 0, 4}};
 
     Raster<int> dispersers(infected.rows(), infected.cols());
     std::vector<std::tuple<int, int>> outside_dispersers;
@@ -211,14 +211,14 @@ int test_with_deterministic_kernel()
         return 1;
     }
     DeterministicDispersalKernel deterministicKernel(DispersalKernelType::Cauchy,
-                          		0.5, 0, dispersers, 0.99, 30, 30);
+                          		dispersers, 0.99, 30, 30, 0.3, 0);
                           		// using a smaller scale value since the test raster is so small
     simulation.disperse(dispersers, susceptible, infected,
                         mortality_tracker, total_hosts,
                         outside_dispersers, weather, weather_coefficient,
                         deterministicKernel, establishment_probability);
-    if (outside_dispersers.size() != 9) {
-        cout << "Deterministic Kernel Cauchy: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be 9\n";
+    if (outside_dispersers.size() != 0) {
+        cout << "Deterministic Kernel Cauchy: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be 0\n";
         return 1;
     }
     if (infected != expected_infected) {
@@ -238,8 +238,8 @@ int test_with_deterministic_kernel()
     movements = {{0, 0, 1, 1, 2}, {0, 1, 0, 0, 3}, {0, 1, 1, 0, 2}};
     movement_schedule = {1, 1};
 	std::vector<std::tuple<int, int>> outside_dispersers2;
-    expected_mortality_tracker = {{1, 3, 1}, {3, 1, 0}, {1, 0, 1}};
-    expected_infected = {{6, 3, 1}, {3, 6, 0}, {1, 0, 3}};
+    expected_mortality_tracker = {{10, 0, 0}, {0, 10, 0}, {0, 0, 2}};
+    expected_infected = {{15, 0, 0}, {0, 15, 0}, {0, 0, 4}};
     dispersers(infected.rows(), infected.cols());
     
     // Exponential
@@ -259,14 +259,14 @@ int test_with_deterministic_kernel()
         return 1;
     }
     DeterministicDispersalKernel deterministicKernel2(DispersalKernelType::Exponential,
-    							 0.5, 0, dispersers, 0.99, 1, 1);
+    							 dispersers, 0.99, 30, 30, 1, 0);
    
     s2.disperse(dispersers, susceptible, infected,
                         mortality_tracker, total_hosts,
                         outside_dispersers2, weather, weather_coefficient,
                         deterministicKernel2, establishment_probability);
-    if (outside_dispersers2.size() != 9) {
-        cout << "Deterministic Kernel Exponential: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be 9\n";
+    if (outside_dispersers2.size() != 0) {
+        cout << "Deterministic Kernel Exponential: There are outside_dispersers (" << outside_dispersers2.size() << ") but there should be 0\n";
         return 1;
     }
     if (infected != expected_infected) {

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -27,7 +27,6 @@
 #include "neighbor_kernel.hpp"
 #include "radial_kernel.hpp"
 #include "simulation.hpp"
-#include "deterministic_kernel.hpp"
 
 #include <map>
 #include <iostream>

--- a/test_simulation.cpp
+++ b/test_simulation.cpp
@@ -183,8 +183,8 @@ int test_with_deterministic_kernel()
     std::vector<std::vector<int>> movements = {{0, 0, 1, 1, 2}, {0, 1, 0, 0, 3}, {0, 1, 1, 0, 2}};
     std::vector<unsigned> movement_schedule = {1, 1};
 
-    Raster<int> expected_mortality_tracker = {{1, 5, 2}, {4, 3, 0}, {2, 0, 2}};
-    Raster<int> expected_infected = {{6, 5, 2}, {4, 8, 0}, {2, 0, 4}};
+    Raster<int> expected_mortality_tracker = {{1, 3, 1}, {3, 1, 0}, {1, 0, 1}};
+    Raster<int> expected_infected = {{6, 3, 1}, {3, 6, 0}, {1, 0, 3}};
 
     Raster<int> dispersers(infected.rows(), infected.cols());
     std::vector<std::tuple<int, int>> outside_dispersers;
@@ -210,14 +210,15 @@ int test_with_deterministic_kernel()
         cout << "Deterministic Kernel Cauchy: dispersers (actual, expected):\n" << dispersers << "  !=\n" << expected_dispersers << "\n";
         return 1;
     }
-    DeterministicDispersalKernel deterministicKernel(3, 3, DispersalKernelType::Cauchy,
-                          		1, 0, dispersers);
+    DeterministicDispersalKernel deterministicKernel(DispersalKernelType::Cauchy,
+                          		0.5, 0, dispersers, 0.99, 30, 30);
+                          		// using a smaller scale value since the test raster is so small
     simulation.disperse(dispersers, susceptible, infected,
                         mortality_tracker, total_hosts,
                         outside_dispersers, weather, weather_coefficient,
                         deterministicKernel, establishment_probability);
-    if (!outside_dispersers.empty()) {
-        cout << "Deterministic Kernel Cauchy: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be none\n";
+    if (outside_dispersers.size() != 9) {
+        cout << "Deterministic Kernel Cauchy: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be 9\n";
         return 1;
     }
     if (infected != expected_infected) {
@@ -236,10 +237,9 @@ int test_with_deterministic_kernel()
     total_hosts = susceptible;
     movements = {{0, 0, 1, 1, 2}, {0, 1, 0, 0, 3}, {0, 1, 1, 0, 2}};
     movement_schedule = {1, 1};
-
-    expected_mortality_tracker = {{1, 5, 2}, {4, 3, 0}, {2, 0, 2}};
-    expected_infected = {{6, 5, 2}, {4, 8, 0}, {2, 0, 4}};
-
+	std::vector<std::tuple<int, int>> outside_dispersers2;
+    expected_mortality_tracker = {{1, 3, 1}, {3, 1, 0}, {1, 0, 1}};
+    expected_infected = {{6, 3, 1}, {3, 6, 0}, {1, 0, 3}};
     dispersers(infected.rows(), infected.cols());
     
     // Exponential
@@ -258,14 +258,15 @@ int test_with_deterministic_kernel()
         cout << "Deterministic Kernel Exponential: dispersers (actual, expected):\n" << dispersers << "  !=\n" << expected_dispersers << "\n";
         return 1;
     }
-    DeterministicDispersalKernel deterministicKernel2(3, 3, DispersalKernelType::Exponential, 1, 0, dispersers);
+    DeterministicDispersalKernel deterministicKernel2(DispersalKernelType::Exponential,
+    							 0.5, 0, dispersers, 0.99, 1, 1);
    
     s2.disperse(dispersers, susceptible, infected,
                         mortality_tracker, total_hosts,
-                        outside_dispersers, weather, weather_coefficient,
+                        outside_dispersers2, weather, weather_coefficient,
                         deterministicKernel2, establishment_probability);
-    if (!outside_dispersers.empty()) {
-        cout << "Deterministic Kernel Exponential: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be none\n";
+    if (outside_dispersers2.size() != 9) {
+        cout << "Deterministic Kernel Exponential: There are outside_dispersers (" << outside_dispersers.size() << ") but there should be 9\n";
         return 1;
     }
     if (infected != expected_infected) {


### PR DESCRIPTION
I have implemented this such that when the deterministic kernel is initialized the probability matrix is created for the entire raster. Then whenever the function is called from Simulation.disperse it creates a smaller matrix (moving window) from the probability matrix. From this, it assigns dispersers as it is called by Simulation and alters the probabilities of each cell in the window matrix so that it remembers where all of the other dispersers are. I also included functions to calculate probabilities based on the Exponential and Cauchy distributions.

Potential problems:

-  I made the moving window have a size related to the number of dispersers that the cell has, but, I can change this to anything else.

- I determined distance by calculating the difference between the row/col values of any cell to the center cell, but I am not sure if this was how you wanted to calculate the distance.

- The way the probability matrix is set up always throws dispersers towards center of the matrix even if the cell of interest is on the far edge of the matrix. For example, if the window is at the far edge of the raster (i.e cell (1,1)) right now it would say that it is more likely for the disperser to go in cell (3,3) because it is closer to the center, when it seems more likely that it would be closer to (1,1). I was not sure if this was what you were expecting or if I misunderstood how to create the probability matrix.