### PR TITLE
Expose the deterministic neighbor kernel in the rest of the API

### DIFF
--- a/kernel_types.hpp
+++ b/kernel_types.hpp
@@ -55,6 +55,7 @@ enum class DispersalKernelType
     Cauchy,  //!< Cauchy dispersal kernel
     Exponential,  //!< Exponential dispersal kernel
     Uniform,  //!< Random uniform dispersal kernel
+    DeterministicNeighbor,  //!< Deterministic immediate neighbor dispersal kernel
     None,  //!< No dispersal kernel (no spread)
 };
 
@@ -72,6 +73,8 @@ DispersalKernelType kernel_type_from_string(const std::string& text)
         return DispersalKernelType::Exponential;
     else if (text == "uniform")
         return DispersalKernelType::Uniform;
+    else if (text == "deterministic-neighbor" || text == "deterministic_neighbor")
+        return DispersalKernelType::DeterministicNeighbor;
     else if (text == "none" || text == "None"
              || text == "NONE" || text.empty())
         return DispersalKernelType::None;

--- a/neighbor_kernel.hpp
+++ b/neighbor_kernel.hpp
@@ -36,6 +36,17 @@ class DeterministicNeighborDispersalKernel
 protected:
     Direction direction_;
 public:
+    /**
+     * Creates kernel based on the spread direction.
+     *
+     * If the spread direction is None, i.e., Direction::None,
+     * the object is created, but it cannot be actually used as a kernel.
+     * If it is called, it throws std::invalid_argument.
+     * This allows creating "default" instance of this object which is
+     * never actually used in the simulation.
+     *
+     * @param dispersal_direction Direction of the spread
+     */
     DeterministicNeighborDispersalKernel(Direction dispersal_direction)
         :
           direction_(dispersal_direction)

--- a/switch_kernel.hpp
+++ b/switch_kernel.hpp
@@ -18,6 +18,7 @@
 
 #include "radial_kernel.hpp"
 #include "uniform_kernel.hpp"
+#include "neighbor_kernel.hpp"
 #include "kernel_types.hpp"
 
 namespace pops {
@@ -37,18 +38,21 @@ protected:
     DispersalKernelType dispersal_kernel_type_;
     RadialDispersalKernel radial_kernel_;
     UniformDispersalKernel uniform_kernel_;
-
+    DeterministicNeighborDispersalKernel deterministic_neighbor_kernel_;
 public:
-    SwitchDispersalKernel(const DispersalKernelType& dispersal_kernel_type,
-                          const RadialDispersalKernel& radial_kernel,
-                          const UniformDispersalKernel& uniform_kernel
-                          )
+    SwitchDispersalKernel(
+            const DispersalKernelType& dispersal_kernel_type,
+            const RadialDispersalKernel& radial_kernel,
+            const UniformDispersalKernel& uniform_kernel,
+            const DeterministicNeighborDispersalKernel& deterministic_neighbor_kernel = DeterministicNeighborDispersalKernel(Direction::None)
+            )
         :
           dispersal_kernel_type_(dispersal_kernel_type),
           // Here we initialize all kernels,
           // although we won't use all of them.
           radial_kernel_(radial_kernel),
-          uniform_kernel_(uniform_kernel)
+          uniform_kernel_(uniform_kernel),
+          deterministic_neighbor_kernel_(deterministic_neighbor_kernel)
     {}
 
     /*! \copydoc RadialDispersalKernel::operator()()
@@ -60,6 +64,9 @@ public:
         if (dispersal_kernel_type_ == DispersalKernelType::Uniform) {
             return uniform_kernel_(generator, row, col);
         }
+        else if (dispersal_kernel_type_ == DispersalKernelType::DeterministicNeighbor) {
+            return deterministic_neighbor_kernel_(generator, row, col);
+        }
         else {
             return radial_kernel_(generator, row, col);
         }
@@ -70,6 +77,8 @@ public:
     static bool supports_kernel(const DispersalKernelType type)
     {
         if (type == DispersalKernelType::Uniform)
+            return true;
+        if (type == DispersalKernelType::DeterministicNeighbor)
             return true;
         else
             return RadialDispersalKernel::supports_kernel(type);


### PR DESCRIPTION
The DeterministicNeighborDispersalKernel was available, but only when the objects are directly constructed by the programmer.
Now the kernel is part of the kernel API alongside other kernels.

The SwitchDispersalKernel constructor now has an additional parameter, but it it optional,
so the API is the same as before if the DeterministicNeighborDispersalKernel is not used
(however, in that case, it needs to be not allowed in the user interface because
the string to kernel enum function will not complain).
