### PR TITLE
Add check for number of simulation units

### DIFF
--- a/scheduling.hpp
+++ b/scheduling.hpp
@@ -112,6 +112,8 @@ public:
     {
         if (start >= end)
             throw std::invalid_argument("Start date must be before end date");
+        if (simulation_num_units <= 0)
+            throw std::invalid_argument("Number of simulation units must be higher than zero");
         Date d(start);
         increase_date(d);
         if (d > end)


### PR DESCRIPTION
This adds a check for number of simulation units (days, months, ...) so it is always greater than zero.
A zero will cause an infinite loop (and allocation).
