### PR TITLE
Add template parameter to SwitchDispersalKernel and the main DispersalKernel

### DIFF
--- a/kernel.hpp
+++ b/kernel.hpp
@@ -75,7 +75,8 @@ namespace pops {
  * See NaturalAnthropogenicDispersalKernel and SwitchDispersalKernel for further
  * documentation.
  */
-typedef NaturalAnthropogenicDispersalKernel<SwitchDispersalKernel, SwitchDispersalKernel> DispersalKernel;
+template<typename IntegerRaster>
+using DispersalKernel = NaturalAnthropogenicDispersalKernel<SwitchDispersalKernel<IntegerRaster>, SwitchDispersalKernel<IntegerRaster>>;
 
 } // namespace pops
 

--- a/switch_kernel.hpp
+++ b/switch_kernel.hpp
@@ -32,17 +32,18 @@ namespace pops {
  * its call in the function call operator, and extend the
  * supports_kernel() function.
  */
+template<typename IntegerRaster>
 class SwitchDispersalKernel
 {
 protected:
     DispersalKernelType dispersal_kernel_type_;
-    RadialDispersalKernel radial_kernel_;
+    RadialDispersalKernel<IntegerRaster> radial_kernel_;
     UniformDispersalKernel uniform_kernel_;
     DeterministicNeighborDispersalKernel deterministic_neighbor_kernel_;
 public:
     SwitchDispersalKernel(
             const DispersalKernelType& dispersal_kernel_type,
-            const RadialDispersalKernel& radial_kernel,
+            const RadialDispersalKernel<IntegerRaster>& radial_kernel,
             const UniformDispersalKernel& uniform_kernel,
             const DeterministicNeighborDispersalKernel& deterministic_neighbor_kernel = DeterministicNeighborDispersalKernel(Direction::None)
             )
@@ -81,7 +82,7 @@ public:
         if (type == DispersalKernelType::DeterministicNeighbor)
             return true;
         else
-            return RadialDispersalKernel::supports_kernel(type);
+            return RadialDispersalKernel<IntegerRaster>::supports_kernel(type);
     }
 };
 


### PR DESCRIPTION
This applies the use of templates added in fd5cb57fbdceab82db1e547ac59425d7e97fd9e1 (#66) to the rest of the code.

It also replaces C-like typedef with C++11 using in order to use the template and modernize the code.
