### PR TITLE
Use Valgrind Memcheck to track memory errors

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,25 @@
+name: Valgrind Memcheck
+
+on:
+- push
+- pull_request
+
+jobs:
+  memcheck:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: make
+    - name: Memcheck
+      run: |
+        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_treatments
+        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_spread_rate
+        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_scheduling
+        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_raster
+        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_simulation
+        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_statistics
+        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_date
+        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_deterministic

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -11,6 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq valgrind
     - name: Build
       run: make
     - name: Memcheck


### PR DESCRIPTION
The more and more complex initialization in PoPS code itself needs checks.
The motivation is problems surfacing with the Model class, specificially
error in deterministic kernel init.
