### PR TITLE
Provide default for max distance in deteministic kernel

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -19,11 +19,11 @@ jobs:
       run: make
     - name: Memcheck
       run: |
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_treatments
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_spread_rate
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_scheduling
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_raster
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_simulation
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_statistics
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_date
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./test_deterministic
+        valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./test_treatments
+        valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./test_spread_rate
+        valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./test_scheduling
+        valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./test_raster
+        valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./test_simulation
+        valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./test_statistics
+        valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./test_date
+        valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./test_deterministic

--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,13 @@
 # generated executables
 a.out
 test_date
+test_deterministic
 test_raster
+test_scheduling
 test_simulation
-test_treatments
 test_spread_rate
 test_statistics
-test_scheduling
+test_treatments
 # generated documentation
 html
 # Qt Creator files

--- a/deterministic_kernel.hpp
+++ b/deterministic_kernel.hpp
@@ -128,7 +128,7 @@ protected:
     int number_of_rows = 0;
     int number_of_columns = 0;
     // maximum distance from center cell to outer cells
-    double max_distance;
+    double max_distance{0};
     Raster<double> probability;
     Raster<double> probability_copy;
     CauchyDistribution cauchy;


### PR DESCRIPTION
This fixes c23f94bb02784a7fa189dab901202240756f6b1e (#79).

It also adds --track-origins=yes to valgrind call.
