### PR TITLE
Bugfix/88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project should be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2020-08-12
+- Exposed class now being removed with treatments
+  * Added exposed class treatments to model class
+
 ## 2020-05-15 - Reducing stochasticity
 
 ### Added

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -185,7 +185,8 @@ public:
                 }
             }
             // remove exposed class when treatment is applied
-            if (model_type == ModelType::SusceptibleExposedInfected && managed) {
+            if (model_type_from_string(config.model_type) == ModelType::SusceptibleExposedInfected
+                    && managed) {
                 for (unsigned exp_index = 0; exp_index < exposed.size(); exp_index++){
                     treatments.manage_mortality(step, exposed[exp_index]);
                 }

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -188,7 +188,7 @@ public:
             if (model_type_from_string(config_.model_type)
                     == ModelType::SusceptibleExposedInfected
                 && managed) {
-                for (unsigned exp_index = 0; exp_index < exposed.size(); exp_index++){
+                for (unsigned exp_index = 0; exp_index < exposed.size(); exp_index++) {
                     treatments.manage_mortality(step, exposed[exp_index]);
                 }
             }

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -184,6 +184,12 @@ public:
                     }
                 }
             }
+            // remove exposed class when treatment is applied
+            if (model_type == ModelType::SusceptibleExposedInfected && managed) {
+                for (unsigned exp_index = 0; exp_index < exposed.size(); exp_index++){
+                    treatments.manage_mortality(current_index, exposed[exp_index]);
+                }
+            }
         }
         if (config_.use_mortality && config_.mortality_schedule()[step]) {
             // only run to the current year of simulation

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -185,7 +185,7 @@ public:
                 }
             }
             // remove exposed class when treatment is applied
-            if (model_type_from_string(config.model_type) == ModelType::SusceptibleExposedInfected
+            if (model_type_from_string(config_.model_type) == ModelType::SusceptibleExposedInfected
                     && managed) {
                 for (unsigned exp_index = 0; exp_index < exposed.size(); exp_index++){
                     treatments.manage_mortality(step, exposed[exp_index]);

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -185,8 +185,9 @@ public:
                 }
             }
             // remove exposed class when treatment is applied
-            if (model_type_from_string(config_.model_type) == ModelType::SusceptibleExposedInfected
-                    && managed) {
+            if (model_type_from_string(config_.model_type)
+                    == ModelType::SusceptibleExposedInfected
+                && managed) {
                 for (unsigned exp_index = 0; exp_index < exposed.size(); exp_index++){
                     treatments.manage_mortality(step, exposed[exp_index]);
                 }

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -171,7 +171,8 @@ public:
         }
         // treatments
         if (config_.use_treatments) {
-            bool managed = treatments.manage(step, infected, susceptible, resistant);
+            bool managed =
+                treatments.manage(step, infected, exposed, susceptible, resistant);
             if (managed && config_.use_mortality) {
                 // same conditions as the mortality code below
                 // TODO: make the mortality timing available as a separate function in
@@ -182,14 +183,6 @@ public:
                     for (int age = 0; age <= max_index; age++) {
                         treatments.manage_mortality(step, mortality_tracker[age]);
                     }
-                }
-            }
-            // remove exposed class when treatment is applied
-            if (model_type_from_string(config_.model_type)
-                    == ModelType::SusceptibleExposedInfected
-                && managed) {
-                for (unsigned exp_index = 0; exp_index < exposed.size(); exp_index++) {
-                    treatments.manage_mortality(step, exposed[exp_index]);
                 }
             }
         }

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -187,7 +187,7 @@ public:
             // remove exposed class when treatment is applied
             if (model_type == ModelType::SusceptibleExposedInfected && managed) {
                 for (unsigned exp_index = 0; exp_index < exposed.size(); exp_index++){
-                    treatments.manage_mortality(current_index, exposed[exp_index]);
+                    treatments.manage_mortality(step, exposed[exp_index]);
                 }
             }
         }

--- a/include/pops/treatments.hpp
+++ b/include/pops/treatments.hpp
@@ -231,7 +231,7 @@ public:
 
     void apply_treatment(
         IntegerRaster& infected,
-        std::vector<IntegerRaster>& exposed,
+        std::vector<IntegerRaster>& exposed_vector,
         IntegerRaster& susceptible,
         IntegerRaster& resistant) override
     {
@@ -249,17 +249,16 @@ public:
                     infected_resistant = this->map_(i, j) ? infected(i, j) : 0;
                 }
                 infected(i, j) -= infected_resistant;
-                for (auto& raster : exposed) {
+                for (auto& exposed : exposed_vector) {
                     int exposed_resistant = 0;
                     if (this->application_ == TreatmentApplication::Ratio) {
-                        exposed_resistant =
-                            raster(i, j) - (raster(i, j) * this->map_(i, j));
+                        exposed_resistant = exposed(i, j) * this->map_(i, j);
                     }
                     else if (
                         this->application_ == TreatmentApplication::AllInfectedInCell) {
-                        exposed_resistant = this->map_(i, j) ? 0 : raster(i, j);
+                        exposed_resistant = this->map_(i, j) ? exposed(i, j) : 0;
                     }
-                    raster(i, j) -= exposed_resistant;
+                    exposed(i, j) -= exposed_resistant;
                     exposed_resistant_sum += exposed_resistant;
                 }
                 resistant(i, j) = infected_resistant + exposed_resistant_sum

--- a/include/pops/treatments.hpp
+++ b/include/pops/treatments.hpp
@@ -83,6 +83,7 @@ public:
     virtual bool should_end(unsigned step) = 0;
     virtual void apply_treatment(
         IntegerRaster& infected,
+        std::vector<IntegerRaster>& exposed,
         IntegerRaster& susceptible,
         IntegerRaster& resistant) = 0;
     virtual void
@@ -162,7 +163,10 @@ public:
         return false;
     }
     void apply_treatment(
-        IntegerRaster& infected, IntegerRaster& susceptible, IntegerRaster&) override
+        IntegerRaster& infected,
+        std::vector<IntegerRaster>& exposed,
+        IntegerRaster& susceptible,
+        IntegerRaster&) override
     {
         for (int i = 0; i < infected.rows(); i++)
             for (int j = 0; j < infected.cols(); j++) {
@@ -173,6 +177,15 @@ public:
                 else if (
                     this->application_ == TreatmentApplication::AllInfectedInCell) {
                     infected(i, j) = this->map_(i, j) ? 0 : infected(i, j);
+                }
+                for (auto& raster : exposed) {
+                    if (this->application_ == TreatmentApplication::Ratio) {
+                        raster(i, j) = raster(i, j) - (raster(i, j) * this->map_(i, j));
+                    }
+                    else if (
+                        this->application_ == TreatmentApplication::AllInfectedInCell) {
+                        raster(i, j) = this->map_(i, j) ? 0 : raster(i, j);
+                    }
                 }
                 susceptible(i, j) =
                     susceptible(i, j) - (susceptible(i, j) * this->map_(i, j));
@@ -218,12 +231,14 @@ public:
 
     void apply_treatment(
         IntegerRaster& infected,
+        std::vector<IntegerRaster>& exposed,
         IntegerRaster& susceptible,
         IntegerRaster& resistant) override
     {
         for (int i = 0; i < infected.rows(); i++)
             for (int j = 0; j < infected.cols(); j++) {
                 int infected_resistant = 0;
+                int exposed_resistant_sum = 0;
                 int susceptible_resistant = susceptible(i, j) * this->map_(i, j);
                 int current_resistant = resistant(i, j);
                 if (this->application_ == TreatmentApplication::Ratio) {
@@ -234,8 +249,21 @@ public:
                     infected_resistant = this->map_(i, j) ? infected(i, j) : 0;
                 }
                 infected(i, j) -= infected_resistant;
-                resistant(i, j) =
-                    infected_resistant + susceptible_resistant + current_resistant;
+                for (auto& raster : exposed) {
+                    int exposed_resistant = 0;
+                    if (this->application_ == TreatmentApplication::Ratio) {
+                        exposed_resistant =
+                            raster(i, j) - (raster(i, j) * this->map_(i, j));
+                    }
+                    else if (
+                        this->application_ == TreatmentApplication::AllInfectedInCell) {
+                        exposed_resistant = this->map_(i, j) ? 0 : raster(i, j);
+                    }
+                    raster(i, j) -= exposed_resistant;
+                    exposed_resistant_sum += exposed_resistant;
+                }
+                resistant(i, j) = infected_resistant + exposed_resistant_sum
+                                  + susceptible_resistant + current_resistant;
                 susceptible(i, j) -= susceptible_resistant;
             }
     }
@@ -325,13 +353,15 @@ public:
     bool manage(
         unsigned current,
         IntegerRaster& infected,
+        std::vector<IntegerRaster>& exposed,
         IntegerRaster& susceptible,
         IntegerRaster& resistant)
     {
         bool changed = false;
         for (unsigned i = 0; i < treatments.size(); i++) {
             if (treatments[i]->should_start(current)) {
-                treatments[i]->apply_treatment(infected, susceptible, resistant);
+                treatments[i]->apply_treatment(
+                    infected, exposed, susceptible, resistant);
                 changed = true;
             }
             else if (treatments[i]->should_end(current)) {

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -378,14 +378,6 @@ int test_deterministic_exponential()
     }
     return 0;
 }
-template<typename T>
-void print_vector(const std::vector<T>& v)
-{
-    for (auto i : v) {
-        cout << i;
-    }
-    cout << "\n";
-}
 
 int test_model_sei_deterministic()
 {
@@ -616,8 +608,6 @@ int test_model_sei_deterministic_with_treatments()
             quarantine,
             zeros,
             movements);
-        print_vector(exposed);
-        cout << infected << "\n";
     }
     if (!outside_dispersers.empty()) {
         cout << "sei_deterministic_with_treatments: There are outside_dispersers ("

--- a/tests/test_treatments.cpp
+++ b/tests/test_treatments.cpp
@@ -40,9 +40,10 @@ int test_application_ratio()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
+    std::vector<Raster<int>> exposed;
 
     treatments.add_treatment(tr1, Date(2020, 1, 1), 0, TreatmentApplication::Ratio);
-    treatments.manage(0, infected, susceptible, resistant);
+    treatments.manage(0, infected, exposed, susceptible, resistant);
 
     Raster<int> treated = {{0, 3}, {5, 42}};
     Raster<int> inf_treated = {{0, 2}, {4, 40}};
@@ -63,9 +64,11 @@ int test_application_all_inf()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
+    std::vector<Raster<int>> exposed;
+
     treatments.add_treatment(
         tr1, Date(2020, 1, 1), 0, TreatmentApplication::AllInfectedInCell);
-    treatments.manage(0, infected, susceptible, resistant);
+    treatments.manage(0, infected, exposed, susceptible, resistant);
 
     Raster<int> treated = {{0, 3}, {5, 42}};
     Raster<int> inf_treated = {{0, 0}, {0, 40}};
@@ -87,8 +90,10 @@ int test_application_ratio_pesticide()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
+    std::vector<Raster<int>> exposed;
+
     treatments.add_treatment(tr1, Date(2020, 5, 1), 7, TreatmentApplication::Ratio);
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     Raster<int> treated = {{10, 6}, {20, 42}};
     Raster<int> inf_treated = {{1, 4}, {16, 40}};
@@ -100,7 +105,7 @@ int test_application_ratio_pesticide()
         num_errors++;
     }
     n = scheduler.schedule_action_date(Date(2020, 5, 3));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{0, 3}, {5, 42}};
     inf_treated = {{0, 2}, {4, 40}};
@@ -112,7 +117,7 @@ int test_application_ratio_pesticide()
         num_errors++;
     }
     n = scheduler.schedule_action_date(Date(2020, 5, 8));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{11, 8}, {32, 42}};
     resist = {{0, 0}, {0, 0}};
@@ -134,10 +139,12 @@ int test_application_all_inf_pesticide()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
+    std::vector<Raster<int>> exposed;
+
     treatments.add_treatment(
         tr1, Date(2020, 5, 1), 7, TreatmentApplication::AllInfectedInCell);
     unsigned n = scheduler.schedule_action_date(Date(2020, 1, 1));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     Raster<int> treated = {{10, 6}, {20, 42}};
     Raster<int> inf_treated = {{1, 4}, {16, 40}};
@@ -149,7 +156,7 @@ int test_application_all_inf_pesticide()
         num_errors++;
     }
     n = scheduler.schedule_action_date(Date(2020, 5, 3));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{0, 3}, {5, 42}};
     inf_treated = {{0, 0}, {0, 40}};
@@ -161,7 +168,7 @@ int test_application_all_inf_pesticide()
         num_errors++;
     }
     n = scheduler.schedule_action_date(Date(2020, 5, 8));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{11, 10}, {36, 42}};
     resist = {{0, 0}, {0, 0}};
@@ -185,10 +192,12 @@ int test_combination()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
+    std::vector<Raster<int>> exposed;
+
     treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
     treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
     unsigned n = scheduler.schedule_action_date(Date(2020, 1, 1));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     Raster<int> treated = {{10, 6}, {20, 42}};
     Raster<int> inf_treated = {{1, 4}, {16, 40}};
@@ -199,7 +208,7 @@ int test_combination()
         num_errors++;
     }
     n = scheduler.schedule_action_date(Date(2020, 5, 3));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{0, 3}, {5, 42}};
     inf_treated = {{0, 2}, {4, 40}};
@@ -210,7 +219,7 @@ int test_combination()
         num_errors++;
     }
     n = scheduler.schedule_action_date(Date(2020, 6, 2));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{0, 0}, {0, 0}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -221,7 +230,7 @@ int test_combination()
         num_errors++;
     }
     n = scheduler.schedule_action_date(Date(2020, 6, 8));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{0, 5}, {9, 82}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -245,11 +254,13 @@ int test_pesticide_temporal_overlap()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
+    std::vector<Raster<int>> exposed;
+
     treatments.add_treatment(tr1, Date(2020, 5, 1), 30, TreatmentApplication::Ratio);
     treatments.add_treatment(tr2, Date(2020, 5, 20), 30, TreatmentApplication::Ratio);
 
     unsigned n = scheduler.schedule_action_date(Date(2020, 5, 1));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     Raster<int> treated = {{0, 0}, {20, 42}};
     Raster<int> inf_treated = {{0, 0}, {16, 40}};
@@ -262,7 +273,7 @@ int test_pesticide_temporal_overlap()
     }
 
     n = scheduler.schedule_action_date(Date(2020, 5, 20));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{0, 0}, {0, 0}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -275,7 +286,7 @@ int test_pesticide_temporal_overlap()
     }
 
     n = scheduler.schedule_action_date(Date(2020, 6, 1));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{11, 10}, {0, 0}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -288,7 +299,7 @@ int test_pesticide_temporal_overlap()
     }
 
     n = scheduler.schedule_action_date(Date(2020, 6, 21));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{11, 10}, {36, 82}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -314,20 +325,22 @@ int test_steering()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
+    std::vector<Raster<int>> exposed;
+
     treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
     treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
     unsigned n = scheduler.schedule_action_date(Date(2020, 1, 1));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 5, 3));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 5, 12));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 6, 1));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 6, 8));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 6, 15));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     Raster<int> treated = {{0, 5}, {9, 82}};
     Raster<int> inf_treated = {{0, 0}, {0, 0}};
@@ -342,17 +355,17 @@ int test_steering()
     resistant = {{0, 0}, {0, 0}};
     infected = {{1, 4}, {16, 40}};
     n = scheduler.schedule_action_date(Date(2020, 1, 1));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 5, 3));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 5, 12));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 6, 1));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 6, 8));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 6, 15));
-    treatments.manage(n, infected, susceptible, resistant);
+    treatments.manage(n, infected, exposed, susceptible, resistant);
 
     treated = {{0, 5}, {9, 82}};
     inf_treated = {{0, 0}, {0, 0}};
@@ -379,23 +392,25 @@ int test_clear()
     Raster<int> susceptible = {{10, 6}, {20, 42}};
     Raster<int> resistant = {{0, 0}, {0, 0}};
     Raster<int> infected = {{1, 4}, {16, 40}};
+    std::vector<Raster<int>> exposed;
+
     treatments.add_treatment(tr1, Date(2020, 5, 1), 0, TreatmentApplication::Ratio);
     treatments.add_treatment(tr2, Date(2020, 6, 1), 7, TreatmentApplication::Ratio);
     treatments.add_treatment(tr3, Date(2020, 6, 8), 7, TreatmentApplication::Ratio);
     unsigned n = scheduler.schedule_action_date(Date(2020, 6, 1));
     treatments.clear_after_step(n);
     n = scheduler.schedule_action_date(Date(2020, 1, 1));
-    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    num_actions += treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 5, 3));
-    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    num_actions += treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 5, 12));
-    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    num_actions += treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 6, 1));
-    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    num_actions += treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 6, 8));
-    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    num_actions += treatments.manage(n, infected, exposed, susceptible, resistant);
     n = scheduler.schedule_action_date(Date(2020, 6, 15));
-    num_actions += treatments.manage(n, infected, susceptible, resistant);
+    num_actions += treatments.manage(n, infected, exposed, susceptible, resistant);
 
     Raster<int> treated = {{0, 5}, {9, 82}};
     Raster<int> inf_treated = {{0, 0}, {0, 0}};


### PR DESCRIPTION
Added loop to remove exposed class. Fixes #88. This is a very easy solution with the current implementation and is incredibly flexible this way. We probably want to rename treatments::manage_mortality but I don't have a good name for this.